### PR TITLE
fix the bug `max_episode_steps` has no effects in Atari

### DIFF
--- a/tianshou/env/atari.py
+++ b/tianshou/env/atari.py
@@ -95,8 +95,9 @@ class preprocessing(object):
                 axis=-1)
         if self.count >= self.max_episode_steps:
             terminal = True
-        self.terminal = terminal
-        return observation, total_reward, is_terminal, info
+        else:
+            terminal = False
+        return observation, total_reward, (terminal or is_terminal), info
 
     def _grayscale_obs(self, output):
         self.env.ale.getScreenGrayscale(output)


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website], and in particular read the [known issues]
- [ ] I have searched through the [issue tracker] for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, sys
  print(tianshou.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/thu-ml/tianshou
  [known issues]: https://github.com/thu-ml/tianshou/#faq-and-known-issues
  [issue tracker]: https://github.com/thu-ml/tianshou/projects/2
