### PR TITLE
Add pickle support for Batch. Fix VectorEnv.

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -1,4 +1,5 @@
 import pytest
+import pickle
 import torch
 import numpy as np
 
@@ -20,6 +21,12 @@ def test_batch():
         assert b.obs == batch[i].obs
     print(batch)
 
+def test_batch_pickle():
+    batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])), np=np.zeros([3, 4]))
+    batch_pk = pickle.loads(pickle.dumps(batch))
+    assert batch.obs.a == batch_pk.obs.a
+    assert torch.all(batch.obs.c == batch_pk.obs.c)
+    assert np.all(batch.np == batch_pk.np)
 
 def test_batch_over_batch():
     batch = Batch(a=[3, 4, 5], b=[4, 5, 6])

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -32,7 +32,8 @@ def test_batch_over_batch():
 
 
 def test_batch_pickle():
-    batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])), np=np.zeros([3, 4]))
+    batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])),
+                  np=np.zeros([3, 4]))
     batch_pk = pickle.loads(pickle.dumps(batch))
     assert batch.obs.a == batch_pk.obs.a
     assert torch.all(batch.obs.c == batch_pk.obs.c)

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -21,12 +21,6 @@ def test_batch():
         assert b.obs == batch[i].obs
     print(batch)
 
-def test_batch_pickle():
-    batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])), np=np.zeros([3, 4]))
-    batch_pk = pickle.loads(pickle.dumps(batch))
-    assert batch.obs.a == batch_pk.obs.a
-    assert torch.all(batch.obs.c == batch_pk.obs.c)
-    assert np.all(batch.np == batch_pk.np)
 
 def test_batch_over_batch():
     batch = Batch(a=[3, 4, 5], b=[4, 5, 6])
@@ -35,6 +29,14 @@ def test_batch_over_batch():
     print(batch2)
     assert batch2.values()[-1] == batch2.c
     assert batch2[-1].b.b == 0
+
+
+def test_batch_pickle():
+    batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])), np=np.zeros([3, 4]))
+    batch_pk = pickle.loads(pickle.dumps(batch))
+    assert batch.obs.a == batch_pk.obs.a
+    assert torch.all(batch.obs.c == batch_pk.obs.c)
+    assert np.all(batch.np == batch_pk.np)
 
 
 def test_batch_from_to_numpy_without_copy():

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -7,8 +7,9 @@ from typing import Any, List, Union, Iterator, Optional
 # Disable pickle warning related to torch, since it has been removed
 # on torch master branch. See Pull Request #39003 for details:
 # https://github.com/pytorch/pytorch/pull/39003
-warnings.filterwarnings("ignore",
-    message="pickle support for Storage will be removed in 1.5.")
+warnings.filterwarnings(
+    "ignore", message="pickle support for Storage will be removed in 1.5.")
+
 
 class Batch:
     """Tianshou provides :class:`~tianshou.data.Batch` as the internal data

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -4,9 +4,11 @@ import pprint
 import numpy as np
 from typing import Any, List, Union, Iterator, Optional
 
-# Disable pickle warning related to torch, since it has been removed on torch master branch.
-# See Pull Request #39003 for details: https://github.com/pytorch/pytorch/pull/39003
-warnings.filterwarnings("ignore", message="pickle support for Storage will be removed in 1.5.")
+# Disable pickle warning related to torch, since it has been removed
+# on torch master branch. See Pull Request #39003 for details:
+# https://github.com/pytorch/pytorch/pull/39003
+warnings.filterwarnings("ignore",
+    message="pickle support for Storage will be removed in 1.5.")
 
 class Batch:
     """Tianshou provides :class:`~tianshou.data.Batch` as the internal data

--- a/tianshou/env/vecenv.py
+++ b/tianshou/env/vecenv.py
@@ -12,7 +12,7 @@ except ImportError:
 from tianshou.env.utils import CloudpickleWrapper
 
 
-class BaseVectorEnv(ABC, gym.Wrapper):
+class BaseVectorEnv(ABC, gym.Env):
     """Base class for vectorized environments wrapper. Usage:
     ::
 
@@ -79,8 +79,14 @@ class BaseVectorEnv(ABC, gym.Wrapper):
 
     @abstractmethod
     def seed(self, seed: Optional[Union[int, List[int]]] = None) -> None:
-        """Set the seed for all environments. Accept ``None``, an int (which
-        will extend ``i`` to ``[i, i + 1, i + 2, ...]``) or a list.
+        """Set the seed for all environments.
+
+        Accept ``None``, an int (which will extend ``i`` to
+        ``[i, i + 1, i + 2, ...]``) or a list.
+
+        :return: The list of seeds used in this env's random number generators.
+        The first value in the list should be the "main" seed, or the value
+        which a reproducer should pass to 'seed'.
         """
         pass
 
@@ -91,7 +97,11 @@ class BaseVectorEnv(ABC, gym.Wrapper):
 
     @abstractmethod
     def close(self) -> None:
-        """Close all of the environments."""
+        """Close all of the environments.
+
+        Environments will automatically close() themselves when garbage
+        collected or when the program exits.
+        """
         pass
 
 


### PR DESCRIPTION
Fix #66 

It also fixes another infinite recursive loop with print to print a VectorEnv because of VectorEnv wrongly inherited from  `gym.Wrapper` instead of `gym.Env`.