### PR TITLE
Fix 'to_tensor' dtype/device forwarding for Batch over Batch.

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -33,9 +33,9 @@ def test_batch_over_batch():
 
 def test_batch_over_batch_to_torch():
     batch = Batch(
-        a=np.ones((1,), dtype=torch.float64),
+        a=np.ones((1,), dtype=np.float64),
         b=Batch(
-            c=np.ones((1,), dtype=torch.float64),
+            c=np.ones((1,), dtype=np.float64),
             d=torch.ones((1,), dtype=torch.float64)
         )
     )
@@ -54,9 +54,9 @@ def test_batch_over_batch_to_torch():
 
 def test_utils_to_torch():
     batch = Batch(
-        a=np.ones((1,), dtype=torch.float64),
+        a=np.ones((1,), dtype=np.float64),
         b=Batch(
-            c=np.ones((1,), dtype=torch.float64),
+            c=np.ones((1,), dtype=np.float64),
             d=torch.ones((1,), dtype=torch.float64)
         )
     )

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -30,13 +30,31 @@ def test_batch_over_batch():
     assert batch2[-1].b.b == 0
 
 
+def test_batch_over_batch_to_torch():
+    batch = Batch(
+        a=np.ones((1,), dtype=torch.float64),
+        b=Batch(
+            c=np.ones((1,), dtype=torch.float64),
+            d=torch.ones((1,), dtype=torch.float64)
+        )
+    )
+    batch.to_torch()
+    assert isinstance(batch.a, torch.Tensor)
+    assert isinstance(batch.b.c, torch.Tensor)
+    assert isinstance(batch.a.dtype, torch.float64)
+    assert isinstance(batch.b.c.dtype, torch.float64)
+    assert isinstance(batch.b.d.dtype, torch.float64)
+    batch.to_torch(dtype=torch.float32)
+    assert isinstance(batch.a.dtype, torch.float32)
+    assert isinstance(batch.b.c.dtype, torch.float32)
+    assert isinstance(batch.b.d.dtype, torch.float32)
+
+
 def test_batch_from_to_numpy_without_copy():
     batch = Batch(a=np.ones((1,)), b=Batch(c=np.ones((1,))))
     a_mem_addr_orig = batch["a"].__array_interface__['data'][0]
     c_mem_addr_orig = batch["b"]["c"].__array_interface__['data'][0]
     batch.to_torch()
-    assert isinstance(batch["a"], torch.Tensor)
-    assert isinstance(batch["b"]["c"], torch.Tensor)
     batch.to_numpy()
     a_mem_addr_new = batch["a"].__array_interface__['data'][0]
     c_mem_addr_new = batch["b"]["c"].__array_interface__['data'][0]

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 import numpy as np
 
-from tianshou.data import Batch
+from tianshou.data import Batch, to_torch
 
 
 def test_batch():
@@ -42,13 +42,32 @@ def test_batch_over_batch_to_torch():
     batch.to_torch()
     assert isinstance(batch.a, torch.Tensor)
     assert isinstance(batch.b.c, torch.Tensor)
-    assert isinstance(batch.a.dtype, torch.float64)
-    assert isinstance(batch.b.c.dtype, torch.float64)
-    assert isinstance(batch.b.d.dtype, torch.float64)
+    assert isinstance(batch.b.d, torch.Tensor)
+    assert batch.a.dtype == torch.float64
+    assert batch.b.c.dtype == torch.float64
+    assert batch.b.d.dtype == torch.float64
     batch.to_torch(dtype=torch.float32)
-    assert isinstance(batch.a.dtype, torch.float32)
-    assert isinstance(batch.b.c.dtype, torch.float32)
-    assert isinstance(batch.b.d.dtype, torch.float32)
+    assert batch.a.dtype == torch.float32
+    assert batch.b.c.dtype == torch.float32
+    assert batch.b.d.dtype == torch.float32
+
+
+def test_utils_to_torch():
+    batch = Batch(
+        a=np.ones((1,), dtype=torch.float64),
+        b=Batch(
+            c=np.ones((1,), dtype=torch.float64),
+            d=torch.ones((1,), dtype=torch.float64)
+        )
+    )
+    a_torch_float = to_torch(batch.a, dtype=torch.float32)
+    assert a_torch_float.dtype == torch.float32
+    a_torch_double = to_torch(batch.a, dtype=torch.float64)
+    assert a_torch_double.dtype == torch.float64
+    batch_torch_float = to_torch(batch, dtype=torch.float32)
+    assert batch_torch_float.a.dtype == torch.float32
+    assert batch_torch_float.b.c.dtype == torch.float32
+    assert batch_torch_float.b.d.dtype == torch.float32
 
 
 def test_batch_from_to_numpy_without_copy():

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -7,6 +7,7 @@ from tianshou.data import Batch
 
 def test_batch():
     batch = Batch(obs=[0], np=np.zeros([3, 4]))
+    assert batch.obs == batch["obs"]
     batch.obs = [1]
     assert batch.obs == [1]
     batch.append(batch)
@@ -52,12 +53,12 @@ def test_batch_over_batch_to_torch():
 
 def test_batch_from_to_numpy_without_copy():
     batch = Batch(a=np.ones((1,)), b=Batch(c=np.ones((1,))))
-    a_mem_addr_orig = batch["a"].__array_interface__['data'][0]
-    c_mem_addr_orig = batch["b"]["c"].__array_interface__['data'][0]
+    a_mem_addr_orig = batch.a.__array_interface__['data'][0]
+    c_mem_addr_orig = batch.b.c.__array_interface__['data'][0]
     batch.to_torch()
     batch.to_numpy()
-    a_mem_addr_new = batch["a"].__array_interface__['data'][0]
-    c_mem_addr_new = batch["b"]["c"].__array_interface__['data'][0]
+    a_mem_addr_new = batch.a.__array_interface__['data'][0]
+    c_mem_addr_new = batch.b.c.__array_interface__['data'][0]
     assert a_mem_addr_new == a_mem_addr_orig
     assert c_mem_addr_new == c_mem_addr_orig
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -182,7 +182,7 @@ class Batch:
                         v = v.type(dtype)
                     self.__dict__[k] = v.to(device)
             elif isinstance(v, Batch):
-                v.to_torch()
+                v.to_torch(dtype, device)
 
     def append(self, batch: 'Batch') -> None:
         """Append a :class:`~tianshou.data.Batch` object to current batch."""

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -28,9 +28,13 @@ def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
         x = torch.from_numpy(x).to(device)
         if dtype is not None:
             x = x.type(dtype)
+    if isinstance(x, torch.Tensor):
+        if dtype is not None:
+            x = x.type(dtype)
+        x = x.to(device)
     elif isinstance(x, dict):
         for k, v in x.items():
             x[k] = to_torch(v, dtype, device)
     elif isinstance(x, Batch):
-        x.to_torch()
+        x.to_torch(dtype, device)
     return x


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

- Batch 'to_tensor' method was not updating dtype and device for 'torch.Tensor' data
- Batch 'to_tensor' was not forwarding dtype and device for Batch over Batch