### PR TITLE
Enable getattr for SubprocVecEnv.

### DIFF
--- a/test/base/env.py
+++ b/test/base/env.py
@@ -1,5 +1,6 @@
-import gym
 import time
+import gym
+from gym.spaces.discrete import Discrete
 
 
 class MyTestEnv(gym.Env):
@@ -7,6 +8,7 @@ class MyTestEnv(gym.Env):
         self.size = size
         self.sleep = sleep
         self.dict_state = dict_state
+        self.action_space = Discrete(1)
         self.reset()
 
     def reset(self, state=0):

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -12,7 +12,7 @@ else:  # pytest
 def test_vecenv(size=10, num=8, sleep=0.001):
     verbose = __name__ == '__main__'
     env_fns = [
-        lambda: MyTestEnv(size=i, sleep=sleep)
+        lambda i=i: MyTestEnv(size=i, sleep=sleep)
         for i in range(size, size + num)
     ]
     venv = [

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -1,5 +1,6 @@
 import time
 import numpy as np
+from gym.spaces.discrete import Discrete
 from tianshou.env import VectorEnv, SubprocVectorEnv, RayVectorEnv
 
 if __name__ == '__main__':
@@ -50,6 +51,9 @@ def test_vecenv(size=10, num=8, sleep=0.001):
         print(f'RayVectorEnv: {t[2]:.6f}s')
     for v in venv:
         assert v.size == list(range(size, size + num))
+        assert v.env_num == num
+        assert v.action_space == [Discrete(1)] * num
+
     for v in venv:
         v.close()
 

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -11,14 +11,8 @@ else:  # pytest
 def test_vecenv(size=10, num=8, sleep=0.001):
     verbose = __name__ == '__main__'
     env_fns = [
-        lambda: MyTestEnv(size=size, sleep=sleep),
-        lambda: MyTestEnv(size=size + 1, sleep=sleep),
-        lambda: MyTestEnv(size=size + 2, sleep=sleep),
-        lambda: MyTestEnv(size=size + 3, sleep=sleep),
-        lambda: MyTestEnv(size=size + 4, sleep=sleep),
-        lambda: MyTestEnv(size=size + 5, sleep=sleep),
-        lambda: MyTestEnv(size=size + 6, sleep=sleep),
-        lambda: MyTestEnv(size=size + 7, sleep=sleep),
+        lambda: MyTestEnv(size=i, sleep=sleep)
+        for i in range(size, size + num)
     ]
     venv = [
         VectorEnv(env_fns),
@@ -54,6 +48,8 @@ def test_vecenv(size=10, num=8, sleep=0.001):
         print(f'VectorEnv: {t[0]:.6f}s')
         print(f'SubprocVectorEnv: {t[1]:.6f}s')
         print(f'RayVectorEnv: {t[2]:.6f}s')
+    for v in venv:
+        assert v.size == list(range(size, size + num))
     for v in venv:
         v.close()
 

--- a/tianshou/env/vecenv.py
+++ b/tianshou/env/vecenv.py
@@ -116,7 +116,21 @@ class VectorEnv(BaseVectorEnv):
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:
         super().__init__(env_fns)
+        self._obs = None
+        self._rew = None
+        self._done = None
+        self._info = None
         self.envs = [_() for _ in env_fns]
+
+    def __getattribute__(self, key):
+        if key not in ('observation_space', 'action_space'):
+            return super().__getattribute__(key)
+        else:
+            return self.__getattr__(key)
+
+    def __getattr__(self, key):
+        return [getattr(env, key) if hasattr(env, key) else None
+                for env in self.envs]
 
     def reset(self, id: Optional[Union[int, List[int]]] = None) -> None:
         if id is None:

--- a/tianshou/env/vecenv.py
+++ b/tianshou/env/vecenv.py
@@ -50,6 +50,8 @@ class BaseVectorEnv(ABC, gym.Env):
         return self.env_num
 
     def __getattribute__(self, key):
+        """Switch between the default attribute getter or one
+           looking at wrapped environment level depending on the key."""
         if key not in ('observation_space', 'action_space'):
             return super().__getattribute__(key)
         else:


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [x] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

So far it is not possible to access the attributes of the environments of a SubprocVecEnv. This would be useful for debug to get the value of some internal buffers, but also to simply get the action and observation spaces for the environments.