### PR TITLE
Fix support of 0-dim numpy array

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -38,14 +38,12 @@ def test_batch():
         'b': np.float64(1.0),
         'c': np.zeros(1),
         'd': Batch(e=np.array(3.0))}])
-    with pytest.raises(IndexError):
-        batch2[-2]
-    with pytest.raises(IndexError):
-        batch2[1]
-    with pytest.raises(IndexError):
-        batch2[0][0]
     assert len(batch2) == 1
-    assert len(batch2[-1]) == 0
+    assert list(batch2[1].keys()) == ['a']
+    assert len(batch2[-2].a.d.keys()) == 0
+    assert len(batch2[-1].keys()) > 0
+    assert batch2[0][0].a.c == 0.0
+    assert isinstance(batch2[0].a.c, np.ndarray)
     assert isinstance(batch2[0].a.b, np.float64)
     assert isinstance(batch2[0].a.d.e, np.float64)
 


### PR DESCRIPTION
Until now, 0-dim np.array or torch.tensor were not properly supported since they have `__len__` method but calling it raises an exception instead of returning 0. Yet, handling 0-dim array is very useful in practice, for instance when stacking an array of observations from a VectorEnv.

This PR also improves the methods `__getitem__`: Index validity is checked explicitly instead of relaying on `try ... catch` mechanism