### PR TITLE
Buffer refactoring to support batch over batch reliably

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -65,10 +65,15 @@ def test_batch():
     assert batch2_sum.a.b == (batch2.a.b + 1.0) * 2
     assert batch2_sum.a.c == (batch2.a.c + 1.0) * 2
     assert batch2_sum.a.d.e == (batch2.a.d.e + 1.0) * 2
-    batch2.a.d[0] = {'e': 4.0}
-    assert batch2.a.d.e[0] == 4.0
-    batch2.a.d[0] = Batch(e=5.0)
-    assert batch2.a.d.e[0] == 5.0
+    batch3 = Batch(a={
+        'c': np.zeros(1),
+        'd': Batch(e=np.array([0.0]), f=np.array([3.0]))})
+    batch3.a.d[0] = {'e': 4.0}
+    assert batch3.a.d.e[0] == 4.0
+    batch3.a.d[0] = Batch(f=5.0)
+    assert batch3.a.d.f[0] == 5.0
+    with pytest.raises(ValueError):
+        batch3.a.d[0] = Batch(f=5.0, g=0.0)
 
 
 def test_batch_over_batch():

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -65,6 +65,10 @@ def test_batch():
     assert batch2_sum.a.b == (batch2.a.b + 1.0) * 2
     assert batch2_sum.a.c == (batch2.a.c + 1.0) * 2
     assert batch2_sum.a.d.e == (batch2.a.d.e + 1.0) * 2
+    batch2.a.d[0] = {'e': 4.0}
+    assert batch2.a.d.e[0] == 4.0
+    batch2.a.d[0] = Batch(e=5.0)
+    assert batch2.a.d.e[0] == 5.0
 
 
 def test_batch_over_batch():
@@ -93,16 +97,20 @@ def test_batch_over_batch():
 def test_batch_cat_and_stack():
     b1 = Batch(a=[{'b': np.float64(1.0), 'd': Batch(e=np.array(3.0))}])
     b2 = Batch(a=[{'b': np.float64(4.0), 'd': {'e': np.array(6.0)}}])
-    b_cat_out = Batch.cat((b1, b2))
-    b_cat_in = copy.deepcopy(b1)
-    b_cat_in.cat_(b2)
-    assert np.all(b_cat_in.a.d.e == b_cat_out.a.d.e)
-    assert np.all(b_cat_in.a.d.e == b_cat_out.a.d.e)
-    assert isinstance(b_cat_in.a.d.e, np.ndarray)
-    assert b_cat_in.a.d.e.ndim == 1
-    b_stack = Batch.stack((b1, b2))
-    assert isinstance(b_stack.a.d.e, np.ndarray)
-    assert b_stack.a.d.e.ndim == 2
+    b12_cat_out = Batch.cat((b1, b2))
+    b12_cat_in = copy.deepcopy(b1)
+    b12_cat_in.cat_(b2)
+    assert np.all(b12_cat_in.a.d.e == b12_cat_out.a.d.e)
+    assert np.all(b12_cat_in.a.d.e == b12_cat_out.a.d.e)
+    assert isinstance(b12_cat_in.a.d.e, np.ndarray)
+    assert b12_cat_in.a.d.e.ndim == 1
+    b12_stack = Batch.stack((b1, b2))
+    assert isinstance(b12_stack.a.d.e, np.ndarray)
+    assert b12_stack.a.d.e.ndim == 2
+    b3 = Batch(a=np.zeros((3, 4)))
+    b4 = Batch(a=np.ones((3, 4)))
+    b34_stack = Batch.stack((b3, b4), axis=1)
+    assert np.all(b34_stack.a == np.stack((b3.a, b4.a), axis=1))
 
 
 def test_batch_over_batch_to_torch():

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -53,7 +53,7 @@ def test_stack(size=5, bufsize=9, stack_num=4):
     env = MyTestEnv(size)
     buf = ReplayBuffer(bufsize, stack_num)
     obs = env.reset(1)
-    for _ in range(15):
+    for i in range(15):
         obs_next, rew, done, info = env.step(1)
         buf.add(obs, 1, rew, done, None, info)
         obs = obs_next

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -53,7 +53,7 @@ def test_stack(size=5, bufsize=9, stack_num=4):
     env = MyTestEnv(size)
     buf = ReplayBuffer(bufsize, stack_num)
     obs = env.reset(1)
-    for i in range(15):
+    for _ in range(15):
         obs_next, rew, done, info = env.step(1)
         buf.add(obs, 1, rew, done, None, info)
         obs = obs_next

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -195,6 +195,9 @@ class Batch:
         if not isinstance(value, (dict, Batch)):
             raise TypeError("Batch does not supported value type "
                             f"{type(value)} for item assignment.")
+        if set(self.keys()) != set(value.keys()):
+            raise ValueError(
+                "Cannot perform item assignment between inconsistent Batch.")
         for key in self.keys():
             if isinstance(self[key], Batch):
                 default = Batch()

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -145,8 +145,8 @@ class Batch:
             if isinstance(index, (int, np.integer)):
                 return -length <= index and index < length
             elif isinstance(index, (list, np.ndarray)):
-                return _valid_bounds(length, min(index)) and \
-                    _valid_bounds(length, max(index))
+                return _valid_bounds(length, np.min(index)) and \
+                    _valid_bounds(length, np.max(index))
             elif isinstance(index, slice):
                 if index.start is not None:
                     start_valid = _valid_bounds(length, index.start)
@@ -173,7 +173,8 @@ class Batch:
                         v, (np.ndarray, torch.Tensor)) or v.ndim > 0):
                     if _valid_bounds(len(v), index):
                         if isinstance(index, (int, np.integer)) or \
-                                not isinstance(v, list):
+                                (isinstance(index, np.ndarray) and \
+                                index.ndim == 0) or not isinstance(v, list):
                             setattr(b, k, v[index])
                         else:
                             setattr(b, k, [v[i] for i in index])
@@ -386,6 +387,8 @@ class Batch:
                     setattr(batch, k, torch.stack(v, axis))
                 elif isinstance(v[0], Batch):
                     setattr(batch, k, Batch.stack(v, axis))
+                elif isinstance(v[0], list):
+                    setattr(batch, k, np.stack(v, axis).tolist())
                 else:
                     s = 'No support for method "stack" with type '\
                         f'{type(v[0])} in class Batch and axis != 0.'

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -187,9 +187,17 @@ class Batch:
 
     def __setitem__(self, index: Union[
                         str, slice, int, np.integer, np.ndarray, List[int]],
-                    batch: Union[dict, 'Batch']) -> None:
+                    batch: Any) -> None:
+        if isinstance(index, str):
+            return setattr(self, index, batch)
+        keys = set(list(self.keys()) + list(batch.keys()))
         for key in self.keys():
-            self[key][index] = batch[key]
+            default = Batch() if isinstance(self[key], Batch) else None
+            self[key][index] = batch.get(key, default)
+            keys.remove(key)
+        for key in keys:
+            self[key] = [None] * self.size
+            self[key][index]= batch.get(key)
 
     def __iadd__(self, val: Union['Batch', Number]):
         if isinstance(val, Batch):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -195,7 +195,6 @@ class Batch:
         if not isinstance(value, (dict, Batch)):
             raise TypeError("Batch does not supported value type "
                             f"{type(value)} for item assignment.")
-        keys = set(list(self.keys()) + list(value.keys()))
         for key in self.keys():
             if isinstance(self[key], Batch):
                 default = Batch()
@@ -207,22 +206,6 @@ class Batch:
             else:
                 default = None
             self[key][index] = value.get(key, default)
-            keys.remove(key)
-        for key in keys:
-            # If self is a nested empty batch, there is no
-            # way to determine the appropriate length.
-            size = self.size
-            if isinstance(index, (int, np.integer)):
-                size = max(size, index + 1)
-            elif isinstance(index, slice):
-                if index.start is not None:
-                    size = max(size, index.start + 1)
-                if index.stop is not None:
-                    size = max(max(size, index.stop + 1), -index.stop)
-            elif isinstance(index, np.ndarray):
-                size = max(max(size, max(index + 1)), max(-index))
-            self[key] = [None] * size
-            self[key][index] = value.get(key)
 
     def __iadd__(self, val: Union['Batch', Number]):
         if isinstance(val, Batch):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -183,6 +183,12 @@ class Batch:
                             f"len {len(self)}.")
             return b
 
+    def __setitem__(self, index: Union[
+                        str, slice, int, np.integer, np.ndarray, List[int]],
+                    batch: Union[dict, 'Batch']) -> None:
+        for key, val in zip(self.keys(), batch.values()):
+            getattr(self, key)[index] = val
+
     def __iadd__(self, val: Union['Batch', Number]):
         if isinstance(val, Batch):
             for k, r, v in zip(self.keys(),

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -195,9 +195,9 @@ class Batch:
         if not isinstance(value, (dict, Batch)):
             raise TypeError("Batch does not supported value type "
                             f"{type(value)} for item assignment.")
-        if set(self.keys()) != set(value.keys()):
+        if not set(value.keys()).issubset(self.keys()):
             raise ValueError(
-                "Cannot perform item assignment between inconsistent Batch.")
+                "Creating keys is not supported by item assignment.")
         for key in self.keys():
             if isinstance(self[key], Batch):
                 default = Batch()
@@ -212,9 +212,7 @@ class Batch:
 
     def __iadd__(self, val: Union['Batch', Number]):
         if isinstance(val, Batch):
-            for k, r, v in zip(self.keys(),
-                               self.values(),
-                               val.values()):
+            for k, r, v in zip(self.keys(), self.values(), val.values()):
                 if r is None:
                     self[k] = r
                 elif isinstance(r, list):
@@ -299,7 +297,7 @@ class Batch:
     def get(self, k: str, d: Optional[Any] = None) -> Union['Batch', Any]:
         """Return self[k] if k in self else d. d defaults to None."""
         if k in self.keys():
-            return getattr(self, k)
+            return self[k]
         return d
 
     def to_numpy(self) -> None:
@@ -316,7 +314,7 @@ class Batch:
                  dtype: Optional[torch.dtype] = None,
                  device: Union[str, int, torch.device] = 'cpu'
                  ) -> None:
-        """Change all numpy.ndarray to torch.Tensor. This is an inplace
+        """Change all numpy.ndarray to torch.Tensor. This is an in-place
         operation.
         """
         if not isinstance(device, torch.device):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -188,8 +188,8 @@ class Batch:
     def __setitem__(self, index: Union[
                         str, slice, int, np.integer, np.ndarray, List[int]],
                     batch: Union[dict, 'Batch']) -> None:
-        for key, val in zip(self.keys(), batch.values()):
-            getattr(self, key)[index] = val
+        for key in self.keys():
+            getattr(self, key)[index] = batch[key]
 
     def __iadd__(self, val: Union['Batch', Number]):
         if isinstance(val, Batch):

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -258,7 +258,7 @@ class ReplayBuffer:
         if stack_num == 0:
             self.done[last_index] = last_done
             if key in self._meta:
-                return {k: self.__dict__['_' + key + '@' + k][indice]
+                return {k: self.get(indice, '_' + key + '@' + k)
                         for k in self._meta[key]}
             else:
                 return self.__dict__[key][indice]

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -120,7 +120,7 @@ class ReplayBuffer(Batch):
                     (self._maxsize, *inst.shape), dtype=inst.dtype))
             elif isinstance(inst, (dict, Batch)):
                 setattr(self, name, Batch([
-                    copy.deepcopy(Batch(inst))
+                    Batch(inst)
                     for _ in range(self._maxsize)
                 ]))
             elif isinstance(inst, (np.generic, Number)):
@@ -217,12 +217,12 @@ class ReplayBuffer(Batch):
         # set last frame done to True
         last_index = (self._index - 1 + self._size) % self._size
         last_done, self.done[last_index] = self.done[last_index], True
-        self.done[last_index] = last_done
         if key == 'obs_next' and (not self._save_s_ or self.obs_next is None):
             indice += 1 - self.done[indice].astype(np.int)
             indice[indice == self._size] = 0
             key = 'obs'
         if stack_num == 0:
+            self.done[last_index] = last_done
             val = getattr(self, key)
             if isinstance(val, Batch) and val.size == 0:
                 return val
@@ -238,6 +238,7 @@ class ReplayBuffer(Batch):
             pre_indice[pre_indice == -1] = self._size - 1
             indice = pre_indice + self.done[pre_indice].astype(np.int)
             indice[indice == self._size] = 0
+        self.done[last_index] = last_done
         if len(stack) == 0 or isinstance(stack[0], Batch):
             stack = Batch.stack(stack, axis=1)
         else:

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -251,6 +251,8 @@ class ReplayBuffer(Batch):
         """Return a data batch: self[index]. If stack_num is set to be > 0,
         return the stacked obs and obs_next with shape [batch, len, ...].
         """
+        if isinstance(index, str):
+            return getattr(self, index)
         return Batch(
             obs=self.get(index, 'obs'),
             act=self.get(index, 'act', stack_num=0),
@@ -408,16 +410,18 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             - self.weight[indice].sum()
         self.weight[indice] = np.power(np.abs(new_weight), self._alpha)
 
-    def __getitem__(self, index: Union[slice, np.ndarray]) -> Batch:
+    def __getitem__(self, index: Union[str, slice, np.ndarray]) -> Batch:
+        if isinstance(index, str):
+            return getattr(self, index)
         return Batch(
             obs=self.get(index, 'obs'),
-            act=self.act[index],
+            act=self.get(index, 'act', stack_num=0),
             # act_=self.get(index, 'act'),  # stacked action, for RNN
-            rew=self.rew[index],
-            done=self.done[index],
+            rew=self.get(index, 'rew', stack_num=0),
+            done=self.get(index, 'done', stack_num=0),
             obs_next=self.get(index, 'obs_next'),
             info=self.get(index, 'info'),
-            weight=self.weight[index],
+            weight=self.get(index, 'weight', stack_num=0),
             policy=self.get(index, 'policy'),
         )
 

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -255,12 +255,12 @@ class ReplayBuffer(Batch):
         """
         return Batch(
             obs=self.get(index, 'obs'),
-            act=self.act[index],
+            act=self.get(index, 'act', stack_num=0),
             # act_=self.get(index, 'act'),  # stacked action, for RNN
-            rew=self.rew[index],
-            done=self.done[index],
+            rew=self.get(index, 'rew', stack_num=0),
+            done=self.get(index, 'done', stack_num=0),
             obs_next=self.get(index, 'obs_next'),
-            info=self.info[index],
+            info=self.get(index, 'info', stack_num=0),
             policy=self.get(index, 'policy'),
         )
 

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -135,6 +135,7 @@ class ReplayBuffer(Batch):
                 "Cannot add data to a buffer with different shape, "
                 f"key: {name}, expect shape: {getattr(self, name).shape[1:]}"
                 f", given shape: {inst.shape}.")
+        getattr(self, name)[self._index] =  inst
 
     def update(self, buffer: 'ReplayBuffer') -> None:
         """Move the data from the given buffer to self."""
@@ -238,9 +239,9 @@ class ReplayBuffer(Batch):
             indice = pre_indice + self.done[pre_indice].astype(np.int)
             indice[indice == self._size] = 0
         if len(stack) == 0 or isinstance(stack[0], Batch):
-            stack = Batch.stack(stack)
+            stack = Batch.stack(stack, axis=1)
         else:
-            stack = np.stack(stack)
+            stack = np.stack(stack, axis=1)
         return stack
 
     def __getitem__(self, index: Union[slice, np.ndarray]) -> Batch:


### PR DESCRIPTION
- Add axis option to Batch `stack` method
- Add support of item assignment for Batch (partial item assignment also supported)
- Generalized slicing using any type that is usually accepted by `np.ndarray` for both `Batch` and `Buffer` classes
- Improve robustness of Batch implement by avoiding using direct assignment
- Remove metadata attribute of Buffer class and inherit directly from Batch. It greatly simplify and clarify the implementation.

This PR incidently fixes the support of deeply nested Batch over Batch for Buffers.
