### PR TITLE
fix #91

### DIFF
--- a/test/discrete/test_pdqn.py
+++ b/test/discrete/test_pdqn.py
@@ -74,7 +74,8 @@ def test_pdqn(args=get_args()):
     # collector
     if args.prioritized_replay > 0:
         buf = PrioritizedReplayBuffer(
-            args.buffer_size, alpha=args.alpha, beta=args.alpha)
+            args.buffer_size, alpha=args.alpha,
+            beta=args.alpha, repeat_sample=True)
     else:
         buf = ReplayBuffer(args.buffer_size)
     train_collector = Collector(


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [x] documentation modification
    + [x] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website], and in particular read the [known issues]
- [ ] I have searched through the [issue tracker] and [issue categories] for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, torch, sys
  print(tianshou.__version__, torch.__version__, sys.version, sys.platform)
  ```

  [source website]: https://github.com/thu-ml/tianshou
  [known issues]: https://github.com/thu-ml/tianshou/#faq-and-known-issues
  [issue categories]: https://github.com/thu-ml/tianshou/projects/2
  [issue tracker]: https://github.com/thu-ml/tianshou/issues?q=

PrioritizedReplayBuffer can sample with replacement now. It should be noted that when setting replace to true, update_weight() will ignore the same value in inside and update the corresponding unique weight.