### PR TITLE
Enable partial stacking at Batch level

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -126,6 +126,13 @@ def test_batch_cat_and_stack():
     b34_stack = Batch.stack((b3, b4), axis=1)
     assert np.all(b34_stack.a == np.stack((b3.a, b4.a), axis=1))
     assert np.all(b34_stack.c.d == list(map(list, zip(b3.c.d, b4.c.d))))
+    b5_dict = np.array([{'a': False, 'b': {'c': 2.0, 'd': 1.0}},
+                        {'a': True, 'b': {'c': 3.0}}])
+    b5 = Batch(b5_dict)
+    assert b5.a[0] == np.array(False) and b5.a[1] == np.array(True)
+    assert np.all(b5.b.c == np.stack([e['b']['c'] for e in b5_dict], axis=0))
+    assert b5.b.d[0] == b5_dict[0]['b']['d']
+    assert b5.b.d[1] == 0.0
 
 
 def test_batch_over_batch_to_torch():

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -36,7 +36,7 @@ def test_replaybuffer(size=10, bufsize=20):
     assert b.info.a[0] == 3 and b.info.a.dtype == np.integer
     assert np.all(b.info.a[1:] == 0)
     assert b.info.b.c[0] == 5.0 and b.info.b.c.dtype == np.inexact
-    assert np.all(np.isnan(b.info.b.c[1:]))
+    assert np.all(b.info.b.c[1:] == 0.0)
 
 
 def test_ignore_obs_next(size=10):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -171,11 +171,15 @@ class Batch:
                 f"Index {index} out of bounds for Batch of len {len(self)}.")
         else:
             b = Batch()
+            is_index_scalar = isinstance(index, (int, np.integer)) or \
+                (isinstance(index, np.ndarray) and index.ndim == 0)
             for k, v in self.items():
                 if isinstance(v, Batch) and len(v.__dict__) == 0:
                     b.__dict__[k] = Batch()
-                else:
+                elif is_index_scalar or not isinstance(v, list):
                     b.__dict__[k] = v[index]
+                else:
+                    b.__dict__[k] = [v[i] for i in index]
             return b
 
     def __setitem__(self, index: Union[

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -435,7 +435,9 @@ class Batch:
                 elif hasattr(v, '__len__') and (not isinstance(
                         v, (np.ndarray, torch.Tensor)) or v.ndim > 0):
                     r.append(len(v))
-            return max(1, min(r) if len(r) > 0 else 0)
+                else:
+                    r.append(1)
+            return min(r) if len(r) > 0 else 0
 
     def split(self, size: Optional[int] = None,
               shuffle: bool = True) -> Iterator['Batch']:

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -108,6 +108,7 @@ class ReplayBuffer:
         return self._size
 
     def __repr__(self) -> str:
+        """Return str(self)."""
         return self.__class__.__name__ + self._meta.__repr__()[5:]
 
     def __getattr__(self, key: str) -> Union['Batch', Any]:

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -1,24 +1,7 @@
 import numpy as np
-from numbers import Number
 from typing import Any, Tuple, Union, Optional
 
-from .batch import Batch
-
-
-def _create_value(inst: Any, size: int) -> Union['Batch', np.ndarray]:
-    if isinstance(inst, np.ndarray):
-        return np.full(shape=(size, *inst.shape),
-                       fill_value=None if inst.dtype == np.inexact else 0,
-                       dtype=inst.dtype)
-    elif isinstance(inst, (dict, Batch)):
-        zero_batch = Batch()
-        for key, val in inst.items():
-            zero_batch.__dict__[key] = _create_value(val, size)
-        return zero_batch
-    elif isinstance(inst, (np.generic, Number)):
-        return _create_value(np.asarray(inst), size)
-    else:  # fall back to np.object
-        return np.array([None for _ in range(size)])
+from .batch import Batch, _create_value
 
 
 class ReplayBuffer:


### PR DESCRIPTION
Allow stacking of inconsistent batches:
```
In [1]: from tianshou.data import Batch, to_numpy ; import numpy as np ; import torch                                                                                                                       
In [2]: Batch(np.array([{'is_success': True, 'reward': {'done': 0.0001, 'direction': -0.11480981}}, 
   ...:                 {'is_success': False, 'reward': {'done': 0.0001}}], dtype=object))                                                                                                                  
Out[2]: 
Batch(
    is_success: array([ True, False]),
    reward: Batch(
                done: array([0.0001, 0.0001]),
                direction: array([-0.11480981,  0.        ]),
            ),
)
```

Before that, the result was unexpected (no failure and different result depending of Batch order).

As you may notice, I also replaced 'nan' in float array by 0.0, since at the end it is usually meaningful and convenient.

It comes with a slight performance improvement: https://github.com/thu-ml/tianshou/issues/96

![output_V2](https://user-images.githubusercontent.com/17752950/85860169-a352c000-b7be-11ea-87d4-223008982ed4.png)
