### PR TITLE
Batch.stack re-implementation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -18,6 +18,9 @@ def test_batch():
     assert b.is_empty()
     b.update(c=[3, 5])
     assert np.allclose(b.c, [3, 5])
+    # mimic the behavior of dict.update, where kwargs can overwrite keys
+    b.update({'a': 2}, a=3)
+    assert b.a == 3
     with pytest.raises(AssertionError):
         Batch({1: 2})
     batch = Batch(a=[torch.ones(3), torch.ones(3)])

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -19,7 +19,7 @@ def test_batch():
     assert batch.obs == batch["obs"]
     batch.obs = [1]
     assert batch.obs == [1]
-    batch.cat_([batch])
+    batch.cat_(batch)
     assert np.allclose(batch.obs, [1, 1])
     assert batch.np.shape == (6, 4)
     assert np.allclose(batch[0].obs, batch[1].obs)
@@ -96,13 +96,13 @@ def test_batch_over_batch():
     for k, v in batch2.items():
         assert np.all(batch2[k] == v)
     assert batch2[-1].b.b == 0
-    batch2.cat_([Batch(c=[6, 7, 8], b=batch)])
+    batch2.cat_(Batch(c=[6, 7, 8], b=batch))
     assert np.allclose(batch2.c, [6, 7, 8, 6, 7, 8])
     assert np.allclose(batch2.b.a, [3, 4, 5, 3, 4, 5])
     assert np.allclose(batch2.b.b, [4, 5, 0, 4, 5, 0])
     d = {'a': [3, 4, 5], 'b': [4, 5, 6]}
     batch3 = Batch(c=[6, 7, 8], b=d)
-    batch3.cat_([Batch(c=[6, 7, 8], b=d)])
+    batch3.cat_(Batch(c=[6, 7, 8], b=d))
     assert np.allclose(batch3.c, [6, 7, 8, 6, 7, 8])
     assert np.allclose(batch3.b.a, [3, 4, 5, 3, 4, 5])
     assert np.allclose(batch3.b.b, [4, 5, 6, 4, 5, 6])
@@ -129,7 +129,7 @@ def test_batch_cat_and_stack():
     b2 = Batch(a=[{'b': np.float64(4.0), 'd': {'e': np.array(6.0)}}])
     b12_cat_out = Batch.cat([b1, b2])
     b12_cat_in = copy.deepcopy(b1)
-    b12_cat_in.cat_([b2])
+    b12_cat_in.cat_(b2)
     assert np.all(b12_cat_in.a.d.e == b12_cat_out.a.d.e)
     assert np.all(b12_cat_in.a.d.e == b12_cat_out.a.d.e)
     assert isinstance(b12_cat_in.a.d.e, np.ndarray)

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -10,6 +10,8 @@ from tianshou.data import Batch, to_torch
 def test_batch():
     assert list(Batch()) == []
     assert Batch().is_empty()
+    assert Batch(b={'c': {}}).is_empty()
+    assert len(Batch(a=[1, 2, 3], b={'c': {}})) == 3
     assert not Batch(a=[1, 2, 3]).is_empty()
     with pytest.raises(AssertionError):
         Batch({1: 2})

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -13,6 +13,11 @@ def test_batch():
     assert Batch(b={'c': {}}).is_empty()
     assert len(Batch(a=[1, 2, 3], b={'c': {}})) == 3
     assert not Batch(a=[1, 2, 3]).is_empty()
+    b = Batch()
+    b.update()
+    assert b.is_empty()
+    b.update(c=[3, 5])
+    assert np.allclose(b.c, [3, 5])
     with pytest.raises(AssertionError):
         Batch({1: 2})
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
@@ -114,10 +119,11 @@ def test_batch_over_batch():
     assert np.allclose(batch2.c, [6, 7, 8, 6, 7, 8])
     assert np.allclose(batch2.b.a, [3, 4, 5, 3, 4, 5])
     assert np.allclose(batch2.b.b, [4, 5, 0, 4, 5, 0])
-    batch2.update(batch2.b)
+    batch2.update(batch2.b, six=[6, 6, 6])
     assert np.allclose(batch2.c, [6, 7, 8, 6, 7, 8])
     assert np.allclose(batch2.a, [3, 4, 5, 3, 4, 5])
     assert np.allclose(batch2.b, [4, 5, 0, 4, 5, 0])
+    assert np.allclose(batch2.six, [6, 6, 6])
     d = {'a': [3, 4, 5], 'b': [4, 5, 6]}
     batch3 = Batch(c=[6, 7, 8], b=d)
     batch3.cat_(Batch(c=[6, 7, 8], b=d))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -86,6 +86,18 @@ def test_batch():
     assert batch3.a.d.f[0] == 5.0
     with pytest.raises(KeyError):
         batch3.a.d[0] = Batch(f=5.0, g=0.0)
+    # auto convert
+    batch4 = Batch(a=np.array(['a', 'b']))
+    assert batch4.a.dtype == np.object  # auto convert to np.object
+    batch4.update(a=np.array(['c', 'd']))
+    assert list(batch4.a) == ['c', 'd']
+    assert batch4.a.dtype == np.object  # auto convert to np.object
+    batch5 = Batch(a=np.array([{'index': 0}]))
+    assert isinstance(batch5.a, Batch)
+    assert np.allclose(batch5.a.index, [0])
+    batch5.b = np.array([{'index': 1}])
+    assert isinstance(batch5.b, Batch)
+    assert np.allclose(batch5.b.index, [1])
 
 
 def test_batch_over_batch():
@@ -100,6 +112,10 @@ def test_batch_over_batch():
     assert np.allclose(batch2.c, [6, 7, 8, 6, 7, 8])
     assert np.allclose(batch2.b.a, [3, 4, 5, 3, 4, 5])
     assert np.allclose(batch2.b.b, [4, 5, 0, 4, 5, 0])
+    batch2.update(batch2.b)
+    assert np.allclose(batch2.c, [6, 7, 8, 6, 7, 8])
+    assert np.allclose(batch2.a, [3, 4, 5, 3, 4, 5])
+    assert np.allclose(batch2.b, [4, 5, 0, 4, 5, 0])
     d = {'a': [3, 4, 5], 'b': [4, 5, 6]}
     batch3 = Batch(c=[6, 7, 8], b=d)
     batch3.cat_(Batch(c=[6, 7, 8], b=d))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -166,7 +166,7 @@ def test_batch_cat_and_stack():
     assert isinstance(b12_stack.a.d.e, np.ndarray)
     assert b12_stack.a.d.e.ndim == 2
 
-    # test batch with incompatible keys
+    # test cat with incompatible keys
     b1 = Batch(a=np.random.rand(3, 4), common=Batch(c=np.random.rand(3, 5)))
     b2 = Batch(b=torch.rand(4, 3), common=Batch(c=np.random.rand(4, 5)))
     test = Batch.cat([b1, b2])
@@ -177,6 +177,7 @@ def test_batch_cat_and_stack():
     assert torch.allclose(test.b, ans.b)
     assert np.allclose(test.common.c, ans.common.c)
 
+    # test stack with compatible keys
     b3 = Batch(a=np.zeros((3, 4)),
                b=torch.ones((2, 5)),
                c=Batch(d=[[1], [2]]))
@@ -193,6 +194,26 @@ def test_batch_cat_and_stack():
     assert np.all(b5.b.c == np.stack([e['b']['c'] for e in b5_dict], axis=0))
     assert b5.b.d[0] == b5_dict[0]['b']['d']
     assert b5.b.d[1] == 0.0
+
+    # test stack with incompatible keys
+    a = Batch(a=1, b=2, c=3)
+    b = Batch(a=4, b=5, d=6)
+    c = Batch(c=7, b=6, d=9)
+    d = Batch.stack([a, b, c])
+    assert np.allclose(d.a, [1, 4, 0])
+    assert np.allclose(d.b, [2, 5, 6])
+    assert np.allclose(d.c, [3, 0, 7])
+    assert np.allclose(d.d, [0, 6, 9])
+
+    b1 = Batch(a=np.random.rand(4, 4), common=Batch(c=np.random.rand(4, 5)))
+    b2 = Batch(b=torch.rand(4, 6), common=Batch(c=np.random.rand(4, 5)))
+    test = Batch.stack([b1, b2])
+    ans = Batch(a=np.stack([b1.a, np.zeros((4, 4))]),
+                b=torch.stack([torch.zeros(4, 6), b2.b]),
+                common=Batch(c=np.stack([b1.common.c, b2.common.c])))
+    assert np.allclose(test.a, ans.a)
+    assert torch.allclose(test.b, ans.b)
+    assert np.allclose(test.common.c, ans.common.c)
 
 
 def test_batch_over_batch_to_torch():

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -609,8 +609,8 @@ class Batch:
 
     @staticmethod
     def stack(batches: List[Union[dict, 'Batch']], axis: int = 0) -> 'Batch':
-        """Stack a list of :class:`~tianshou.data.Batch` object
-        into a single new batch.
+        """Stack a list of :class:`~tianshou.data.Batch` object into a single
+        new batch.
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -259,8 +259,7 @@ class Batch:
                         v_ = None
                         if not isinstance(v, np.ndarray) and \
                                 all(isinstance(e, torch.Tensor) for e in v):
-                            v_ = torch.stack(v)
-                            self.__dict__[k] = v_
+                            self.__dict__[k] = torch.stack(v)
                             continue
                         else:
                             v_ = np.asanyarray(v)
@@ -333,9 +332,8 @@ class Batch:
         else:
             raise IndexError("Cannot access item from empty Batch object.")
 
-    def __setitem__(
-            self,
-            index: Union[str, slice, int, np.integer, np.ndarray, List[int]],
+    def __setitem__(self, index: Union[
+            str, slice, int, np.integer, np.ndarray, List[int]],
             value: Any) -> None:
         """Assign value to self[index]."""
         if isinstance(value, np.ndarray):
@@ -454,10 +452,8 @@ class Batch:
             elif isinstance(v, Batch):
                 v.to_numpy()
 
-    def to_torch(self,
-                 dtype: Optional[torch.dtype] = None,
-                 device: Union[str, int, torch.device] = 'cpu'
-                 ) -> None:
+    def to_torch(self, dtype: Optional[torch.dtype] = None,
+                 device: Union[str, int, torch.device] = 'cpu') -> None:
         """Change all numpy.ndarray to torch.Tensor. This is an in-place
         operation.
         """
@@ -473,27 +469,15 @@ class Batch:
                     v = v.type(dtype)
                 self.__dict__[k] = v
             elif isinstance(v, torch.Tensor):
-                if dtype is not None and v.dtype != dtype:
-                    must_update_tensor = True
-                elif v.device.type != device.type:
-                    must_update_tensor = True
-                elif device.index is not None and \
+                if dtype is not None and v.dtype != dtype or \
+                        v.device.type != device.type or \
+                        device.index is not None and \
                         device.index != v.device.index:
-                    must_update_tensor = True
-                else:
-                    must_update_tensor = False
-                if must_update_tensor:
                     if dtype is not None:
                         v = v.type(dtype)
                     self.__dict__[k] = v.to(device)
             elif isinstance(v, Batch):
                 v.to_torch(dtype, device)
-
-    def append(self, batch: 'Batch') -> None:
-        warnings.warn('Method :meth:`~tianshou.data.Batch.append` will be '
-                      'removed soon, please use '
-                      ':meth:`~tianshou.data.Batch.cat`')
-        return self.cat_(batch)
 
     def cat_(self, batch: 'Batch') -> None:
         """Concatenate a :class:`~tianshou.data.Batch` object into current

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -544,10 +544,9 @@ class Batch:
                         arrs.append(e.get(k, pad))
                     self.__dict__[k] = torch.cat(arrs)
                 else:
-                    raise TypeError(f"cannot cat value with type "
-                                    f"{type(value)},we only support"
-                                    f" dict, Batch, np.ndarray, "
-                                    f"and torch.Tensor")
+                    raise TypeError(
+                        f"cannot cat value with type {type(value)}, we only "
+                        "support dict, Batch, np.ndarray, and torch.Tensor")
 
     @staticmethod
     def cat(batches: List[Union[dict, 'Batch']]) -> 'Batch':

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -654,16 +654,13 @@ class Batch:
     def update(self, batch: Optional[Union[dict, 'Batch']] = None,
                **kwargs) -> None:
         """Update this batch from another dict/Batch."""
+        if batch is None:
+            self.update(kwargs)
+            return
         if isinstance(batch, dict):
             batch = Batch(batch)
-        if batch is not None:
-            for k, v in batch.items():
-                self.__dict__[k] = v
-        if kwargs is not None:
-            batch = Batch(kwargs)
-        if batch is not None:
-            for k, v in batch.items():
-                self.__dict__[k] = v
+        for k, v in batch.items():
+            self.__dict__[k] = v
 
     def __len__(self) -> int:
         """Return len(self)."""

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -479,10 +479,13 @@ class Batch:
             elif isinstance(v, Batch):
                 v.to_torch(dtype, device)
 
-    def cat_(self, batches: List[Union[dict, 'Batch']]) -> None:
-        """Concatenate a list of :class:`~tianshou.data.Batch` objects
-        into current batch.
+    def cat_(self,
+             batches: Union['Batch', List[Union[dict, 'Batch']]]) -> None:
+        """Concatenate a list of (or one) :class:`~tianshou.data.Batch`
+        objects into current batch.
         """
+        if isinstance(batches, Batch):
+            batches = [batches]
         if len(batches) == 0:
             return
         batches = [x if isinstance(x, Batch) else Batch(x) for x in batches]

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -482,8 +482,8 @@ class Batch:
 
     def cat_(self,
              batches: Union['Batch', List[Union[dict, 'Batch']]]) -> None:
-        """Concatenate a list of (or one) :class:`~tianshou.data.Batch`
-        objects into current batch.
+        """Concatenate a list of (or one) :class:`~tianshou.data.Batch` objects
+        into current batch.
         """
         if isinstance(batches, Batch):
             batches = [batches]
@@ -521,7 +521,7 @@ class Batch:
                     if isinstance(val, (dict, Batch)):
                         is_dict = True
                     else:
-                        # ndarray or torch.Tensor
+                        # np.ndarray or torch.Tensor
                         value = val
                     break
             if is_dict:
@@ -552,17 +552,21 @@ class Batch:
 
     @staticmethod
     def cat(batches: List[Union[dict, 'Batch']]) -> 'Batch':
-        """Concatenate a list of :class:`~tianshou.data.Batch` object into a single
-        new batch. For keys that are not shared across all batches,
+        """Concatenate a list of :class:`~tianshou.data.Batch` object into a
+        single new batch. For keys that are not shared across all batches,
         batches that do not have these keys will be padded by zeros with
-        appropriate shapes.
-        e.g.
-        a = Batch(a=shape(3,4), common=Batch(c=shape(3, 5)))
-        b = Batch(b=shape(4,3), common=Batch(c=shape(4, 5)))
-        c = Batch.cat([b, c])
-        c.a.shape: (7, 4)
-        c.b.shape: (7, 3)
-        c.common.c.shape: (7, 5)
+        appropriate shapes. E.g.
+        ::
+
+            >>> a = Batch(a=np.zeros([3, 4]), common=Batch(c=np.zeros([3, 5])))
+            >>> b = Batch(b=np.zeros([4, 3]), common=Batch(c=np.zeros([4, 5])))
+            >>> c = Batch.cat([a, b])
+            >>> c.a.shape
+            (7, 4)
+            >>> c.b.shape
+            (7, 3)
+            >>> c.common.c.shape
+            (7, 5)
         """
         batch = Batch()
         batch.cat_(batches)
@@ -571,8 +575,8 @@ class Batch:
     def stack_(self,
                batches: List[Union[dict, 'Batch']],
                axis: int = 0) -> None:
-        """Stack a list of :class:`~tianshou.data.Batch` object
-        into current batch.
+        """Stack a list of :class:`~tianshou.data.Batch` object into current
+        batch.
         """
         if len(self.__dict__) > 0:
             batches = [self] + list(batches)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -651,7 +651,19 @@ class Batch:
     @staticmethod
     def stack(batches: List[Union[dict, 'Batch']], axis: int = 0) -> 'Batch':
         """Stack a list of :class:`~tianshou.data.Batch` object into a single
-        new batch.
+        new batch. For keys that are not shared across all batches,
+        batches that do not have these keys will be padded by zeros. E.g.
+        ::
+
+            >>> a = Batch(a=np.zeros([4, 4]), common=Batch(c=np.zeros([4, 5])))
+            >>> b = Batch(b=np.zeros([4, 6]), common=Batch(c=np.zeros([4, 5])))
+            >>> c = Batch.stack([a, b])
+            >>> c.a.shape
+            (8, 4)
+            >>> c.b.shape
+            (8, 6)
+            >>> c.common.c.shape
+            (8, 5)
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -666,7 +666,7 @@ class Batch:
         """Return len(self)."""
         r = []
         for v in self.__dict__.values():
-            if isinstance(v, Batch) and len(v.__dict__) == 0:
+            if isinstance(v, Batch) and v.is_empty():
                 continue
             elif hasattr(v, '__len__') and (not isinstance(
                     v, (np.ndarray, torch.Tensor)) or v.ndim > 0):
@@ -678,7 +678,9 @@ class Batch:
         return min(r)
 
     def is_empty(self):
-        return len(self.__dict__.keys()) == 0
+        return not any(
+            not x.is_empty() if isinstance(x, Batch)
+            else hasattr(x, '__len__') and len(x) > 0 for x in self.values())
 
     @property
     def shape(self) -> List[int]:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -661,6 +661,8 @@ class Batch:
             batch = Batch(batch)
         for k, v in batch.items():
             self.__dict__[k] = v
+        if kwargs:
+            self.update(kwargs)
 
     def __len__(self) -> int:
         """Return len(self)."""

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -293,7 +293,8 @@ class Batch:
                 value = np.array(value)
                 if not issubclass(value.dtype.type, (np.bool_, np.number)):
                     value = value.astype(np.object)
-        elif isinstance(value, dict):
+        elif isinstance(value, dict) or isinstance(value, np.ndarray) \
+                and value.dtype == np.object and _is_batch_set(value):
             value = Batch(value)
         self.__dict__[key] = value
 
@@ -649,6 +650,20 @@ class Batch:
         :class:`~tianshou.data.Batch`.
         """
         return deepcopy(batch).empty_(index)
+
+    def update(self, batch: Optional[Union[dict, 'Batch']] = None,
+               **kwargs) -> None:
+        """Update this batch from another dict/Batch."""
+        if isinstance(batch, dict):
+            batch = Batch(batch)
+        if batch is not None:
+            for k, v in batch.items():
+                self.__dict__[k] = v
+        if kwargs is not None:
+            batch = Batch(kwargs)
+        if batch is not None:
+            for k, v in batch.items():
+                self.__dict__[k] = v
 
     def __len__(self) -> int:
         """Return len(self)."""

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -520,8 +520,7 @@ class Batch:
                 if val is not None:
                     if isinstance(val, (dict, Batch)):
                         is_dict = True
-                    else:
-                        # np.ndarray or torch.Tensor
+                    else:  # np.ndarray or torch.Tensor
                         value = val
                     break
             if is_dict:

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -108,8 +108,7 @@ class ReplayBuffer:
         super().__init__()
         self._maxsize = size
         self._stack = stack_num
-        assert stack_num != 1, \
-            'stack_num should greater than 1'
+        assert stack_num != 1, 'stack_num should greater than 1'
         self._avail = sample_avail and stack_num > 1
         self._avail_index = []
         self._save_s_ = not ignore_obs_next
@@ -136,12 +135,11 @@ class ReplayBuffer:
         except KeyError:
             self._meta.__dict__[name] = _create_value(inst, self._maxsize)
             value = self._meta.__dict__[name]
-        if isinstance(inst, np.ndarray) and \
-                value.shape[1:] != inst.shape:
+        if isinstance(inst, np.ndarray) and value.shape[1:] != inst.shape:
             raise ValueError(
                 "Cannot add data to a buffer with different shape, key: "
-                f"{name}, expect shape: {value.shape[1:]}"
-                f", given shape: {inst.shape}.")
+                f"{name}, expect shape: {value.shape[1:]}, "
+                f"given shape: {inst.shape}.")
         try:
             value[self._index] = inst
         except KeyError:
@@ -357,7 +355,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         self._weight_sum = 0.0
         self._amortization_freq = 50
         self._replace = replace
-        self._meta.__dict__['weight'] = np.zeros(size, dtype=np.float64)
+        self._meta.weight = np.zeros(size, dtype=np.float64)
 
     def add(self,
             obs: Union[dict, np.ndarray],
@@ -372,7 +370,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         """Add a batch of data into replay buffer."""
         # we have to sacrifice some convenience for speed
         self._weight_sum += np.abs(weight) ** self._alpha - \
-            self._meta.__dict__['weight'][self._index]
+            self._meta.weight[self._index]
         self._add_to_buffer('weight', np.abs(weight) ** self._alpha)
         super().add(obs, act, rew, done, obs_next, info, policy)
 
@@ -410,13 +408,9 @@ class PrioritizedReplayBuffer(ReplayBuffer):
                 f"batch_size should be less than {len(self)}, \
                     or set replace=True")
         batch = self[indice]
-        impt_weight = Batch(
-            impt_weight=(self._size * p) ** (-self._beta))
+        impt_weight = Batch(impt_weight=(self._size * p) ** (-self._beta))
         batch.cat_(impt_weight)
         return batch, indice
-
-    def reset(self) -> None:
-        super().reset()
 
     def update_weight(self, indice: Union[slice, np.ndarray],
                       new_weight: np.ndarray) -> None:

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -408,8 +408,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
                 f"batch_size should be less than {len(self)}, \
                     or set replace=True")
         batch = self[indice]
-        impt_weight = Batch(impt_weight=(self._size * p) ** (-self._beta))
-        batch.cat_([impt_weight])
+        batch["impt_weight"] = (self._size * p) ** (-self._beta)
         return batch, indice
 
     def update_weight(self, indice: Union[slice, np.ndarray],

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -409,7 +409,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
                     or set replace=True")
         batch = self[indice]
         impt_weight = Batch(impt_weight=(self._size * p) ** (-self._beta))
-        batch.cat_(impt_weight)
+        batch.cat_([impt_weight])
         return batch, indice
 
     def update_weight(self, indice: Union[slice, np.ndarray],

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -426,7 +426,7 @@ class Collector(object):
                 if batch_size and cur_batch or batch_size <= 0:
                     batch, indice = b.sample(cur_batch)
                     batch = self.process_fn(batch, b, indice)
-                    batch_data.cat_(batch)
+                    batch_data.cat_([batch])
         else:
             batch_data, indice = self.buffer.sample(batch_size)
             batch_data = self.process_fn(batch_data, self.buffer, indice)

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -426,7 +426,7 @@ class Collector(object):
                 if batch_size and cur_batch or batch_size <= 0:
                     batch, indice = b.sample(cur_batch)
                     batch = self.process_fn(batch, b, indice)
-                    batch_data.cat_([batch])
+                    batch_data.cat_(batch)
         else:
             batch_data, indice = self.buffer.sample(batch_size)
             batch_data = self.process_fn(batch_data, self.buffer, indice)


### PR DESCRIPTION
For keys that are not shared across all batches, batches that do not have these keys will be padded by zeros. E.g.

            >>> a = Batch(a=np.zeros([4, 4]), common=Batch(c=np.zeros([4, 5])))
            >>> b = Batch(b=np.zeros([4, 6]), common=Batch(c=np.zeros([4, 5])))
            >>> c = Batch.stack([a, b])
            >>> c.a.shape
            (8, 4)
            >>> c.b.shape
            (8, 6)
            >>> c.common.c.shape
            (8, 5)