### PR TITLE
Fix padding of inconsistent keys with Batch.stack and Batch.cat

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -166,7 +166,7 @@ def test_batch_cat_and_stack():
     assert isinstance(b12_stack.a.d.e, np.ndarray)
     assert b12_stack.a.d.e.ndim == 2
 
-    # test batch with incompatible keys
+    # test cat with incompatible keys
     b1 = Batch(a=np.random.rand(3, 4), common=Batch(c=np.random.rand(3, 5)))
     b2 = Batch(b=torch.rand(4, 3), common=Batch(c=np.random.rand(4, 5)))
     test = Batch.cat([b1, b2])
@@ -177,6 +177,7 @@ def test_batch_cat_and_stack():
     assert torch.allclose(test.b, ans.b)
     assert np.allclose(test.common.c, ans.common.c)
 
+    # test stack with compatible keys
     b3 = Batch(a=np.zeros((3, 4)),
                b=torch.ones((2, 5)),
                c=Batch(d=[[1], [2]]))
@@ -193,6 +194,26 @@ def test_batch_cat_and_stack():
     assert np.all(b5.b.c == np.stack([e['b']['c'] for e in b5_dict], axis=0))
     assert b5.b.d[0] == b5_dict[0]['b']['d']
     assert b5.b.d[1] == 0.0
+
+    # test stack with incompatible keys
+    a = Batch(a=1, b=2, c=3)
+    b = Batch(a=4, b=5, d=6)
+    c = Batch(c=7, b=6, d=9)
+    d = Batch.stack([a, b, c])
+    assert np.allclose(d.a, [1, 4, 0])
+    assert np.allclose(d.b, [2, 5, 6])
+    assert np.allclose(d.c, [3, 0, 7])
+    assert np.allclose(d.d, [0, 6, 9])
+
+    b1 = Batch(a=np.random.rand(4, 4), common=Batch(c=np.random.rand(4, 5)))
+    b2 = Batch(b=torch.rand(4, 6), common=Batch(c=np.random.rand(4, 5)))
+    test = Batch.stack([b1, b2])
+    ans = Batch(a=np.stack([b1.a, np.zeros((4, 4))]),
+                b=torch.stack([torch.zeros(4, 6), b2.b]),
+                common=Batch(c=np.stack([b1.common.c, b2.common.c])))
+    assert np.allclose(test.a, ans.a)
+    assert torch.allclose(test.b, ans.b)
+    assert np.allclose(test.common.c, ans.common.c)
 
 
 def test_batch_over_batch_to_torch():

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -31,8 +31,10 @@ def _create_value(inst: Any, size: int, stack=True) -> Union[
         of (10, 3, 5), otherwise (10, 5)
     """
     has_shape = isinstance(inst, (np.ndarray, torch.Tensor))
-    is_scalar = isinstance(inst, Number) or \
-                issubclass(inst.__class__, np.generic) or (has_shape and not inst.shape)
+    is_scalar = \
+        isinstance(inst, Number) or \
+        issubclass(inst.__class__, np.generic) or \
+        (has_shape and not inst.shape)
     if not stack and is_scalar:
         # here we do not consider scalar types, following the
         # behavior of numpy which does not support concatenation

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -535,11 +535,11 @@ class Batch:
                 val = e.get(k, None)
                 if val is not None:
                     try:
-                        self.__dict__[k][sum_lens[i]:sum_lens[i+1]] = val
+                        self.__dict__[k][sum_lens[i]:sum_lens[i + 1]] = val
                     except KeyError:
                         self.__dict__[k] = \
                             _create_value(val, sum_lens[-1], stack=False)
-                        self.__dict__[k][sum_lens[i]:sum_lens[i+1]] = val
+                        self.__dict__[k][sum_lens[i]:sum_lens[i + 1]] = val
 
     @staticmethod
     def cat(batches: List[Union[dict, 'Batch']]) -> 'Batch':
@@ -624,9 +624,8 @@ class Batch:
 
         .. note::
 
-            If there are keys that are not shared across all batches,
-            ``stack`` with ``axis!=0`` is undefined, and will cause an
-            exception.
+            If there are keys that are not shared across all batches, ``stack``
+            with ``axis != 0`` is undefined, and will cause an exception.
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -589,6 +589,10 @@ class Batch:
                     v = v.astype(np.object)
                 self.__dict__[k] = v
         keys_partial = set.difference(set.union(*keys_map), keys_shared)
+        if keys_partial and axis != 0:
+            raise ValueError(
+                f"Stack of Batch with non-shared keys {keys_partial}"
+                f" is only supported with axis=0, but got axis={axis}!")
         _assert_type_keys(keys_partial)
         for k in keys_partial:
             for i, e in enumerate(batches):
@@ -617,6 +621,12 @@ class Batch:
             (2, 4, 6)
             >>> c.common.c.shape
             (2, 4, 5)
+
+        .. note::
+
+            If there are keys that are not shared across all batches,
+            ``stack`` with ``axis!=0`` is undefined, and will cause an
+            exception.
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -651,7 +651,19 @@ class Batch:
     @staticmethod
     def stack(batches: List[Union[dict, 'Batch']], axis: int = 0) -> 'Batch':
         """Stack a list of :class:`~tianshou.data.Batch` object into a single
-        new batch.
+        new batch. For keys that are not shared across all batches,
+        batches that do not have these keys will be padded by zeros. E.g.
+        ::
+
+            >>> a = Batch(a=np.zeros([4, 4]), common=Batch(c=np.zeros([4, 5])))
+            >>> b = Batch(b=np.zeros([4, 6]), common=Batch(c=np.zeros([4, 5])))
+            >>> c = Batch.stack([a, b])
+            >>> c.a.shape
+            (8, 4)
+            >>> c.b.shape
+            (8, 6)
+            >>> c.common.c.shape
+            (8, 5)
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -516,8 +516,7 @@ class Batch:
             sum_lens.append(sum_lens[-1] + x)
         keys_map = list(map(lambda e: set(e.keys()), batches))
         keys_shared = set.intersection(*keys_map)
-        values_shared = [
-            [e[k] for e in batches] for k in keys_shared]
+        values_shared = [[e[k] for e in batches] for k in keys_shared]
         _assert_type_keys(keys_shared)
         for k, v in zip(keys_shared, values_shared):
             if all(isinstance(e, (dict, Batch)) for e in v):
@@ -577,8 +576,7 @@ class Batch:
             batches = [self] + list(batches)
         keys_map = list(map(lambda e: set(e.keys()), batches))
         keys_shared = set.intersection(*keys_map)
-        values_shared = [
-            [e[k] for e in batches] for k in keys_shared]
+        values_shared = [[e[k] for e in batches] for k in keys_shared]
         _assert_type_keys(keys_shared)
         for k, v in zip(keys_shared, values_shared):
             if all(isinstance(e, (dict, Batch)) for e in v):
@@ -614,11 +612,11 @@ class Batch:
             >>> b = Batch(b=np.zeros([4, 6]), common=Batch(c=np.zeros([4, 5])))
             >>> c = Batch.stack([a, b])
             >>> c.a.shape
-            (8, 4)
+            (2, 4, 4)
             >>> c.b.shape
-            (8, 6)
+            (2, 4, 6)
             >>> c.common.c.shape
-            (8, 5)
+            (2, 4, 5)
         """
         batch = Batch()
         batch.stack_(batches, axis)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -591,8 +591,8 @@ class Batch:
         keys_partial = set.difference(set.union(*keys_map), keys_shared)
         if keys_partial and axis != 0:
             raise ValueError(
-                f"Stack of Batch with non-shared keys {keys_partial}"
-                f" is only supported with axis=0, but got axis={axis}!")
+                f"Stack of Batch with non-shared keys {keys_partial} "
+                f"is only supported with axis=0, but got axis={axis}!")
         _assert_type_keys(keys_partial)
         for k in keys_partial:
             for i, e in enumerate(batches):


### PR DESCRIPTION
1. For keys that are not shared across all batches, batches that do not have these keys will be padded by zeros. E.g.

```python
>>> a = Batch(a=np.zeros([4, 4]), common=Batch(c=np.zeros([4, 5])))
>>> b = Batch(b=np.zeros([4, 6]), common=Batch(c=np.zeros([4, 5])))
>>> c = Batch.stack([a, b])
>>> c.a.shape
(8, 4)
>>> c.b.shape
(8, 6)
>>> c.common.c.shape
(8, 5)
```

2. simplify ``Batch.cat_``
3. raise exception for stacking with partial keys and axis!=0