### PR TITLE
Improve to_torch/to_numpy converters

### DIFF
--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -35,6 +35,10 @@ def test_batch():
         Batch(a=[np.zeros((3, 2)), np.zeros((3, 3))])
     with pytest.raises(TypeError):
         Batch(a=[torch.zeros((2, 3)), torch.zeros((3, 3))])
+    with pytest.raises(TypeError):
+        Batch(a=[torch.zeros(3,3), np.zeros([3,3])])
+    with pytest.raises(TypeError):
+        Batch(a=[1, np.zeros([3,3]), torch.zeros(3,3)])
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
     assert torch.allclose(batch.a, torch.ones(2, 3))
     batch = Batch(obs=[0], np=np.zeros([3, 4]))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -41,6 +41,7 @@ def test_batch():
         Batch(a=[1, np.zeros((3, 3)), torch.zeros((3, 3))])
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
     assert torch.allclose(batch.a, torch.ones(2, 3))
+    Batch(a=[])
     batch = Batch(obs=[0], np=np.zeros([3, 4]))
     assert batch.obs == batch["obs"]
     batch.obs = [1]

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -36,9 +36,9 @@ def test_batch():
     with pytest.raises(TypeError):
         Batch(a=[torch.zeros((2, 3)), torch.zeros((3, 3))])
     with pytest.raises(TypeError):
-        Batch(a=[torch.zeros(3,3), np.zeros([3,3])])
+        Batch(a=[torch.zeros((3, 3)), np.zeros((3, 3))])
     with pytest.raises(TypeError):
-        Batch(a=[1, np.zeros([3,3]), torch.zeros(3,3)])
+        Batch(a=[1, np.zeros((3, 3)), torch.zeros((3, 3))])
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
     assert torch.allclose(batch.a, torch.ones(2, 3))
     batch = Batch(obs=[0], np=np.zeros([3, 4]))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -333,10 +333,14 @@ def test_utils_to_torch():
     data_list_3_torch = to_torch(data_list_3)
     assert isinstance(data_list_3_torch, list)
     assert isinstance(data_list_3_torch[0], torch.Tensor)
-    data_list_4 = [np.zeros(2), np.zeros((3, 3))]
+    data_list_4 = [np.zeros((2, 3)), np.zeros((3, 3))]
     data_list_4_torch = to_torch(data_list_4)
     assert isinstance(data_list_4_torch, list)
     assert isinstance(data_list_4_torch[0], torch.Tensor)
+    data_list_5 = [np.zeros(2), np.zeros((3, 3))]
+    data_list_5_torch = to_torch(data_list_5)
+    assert isinstance(data_list_5_torch, list)
+    assert isinstance(data_list_5_torch[0], torch.Tensor)
     data_array = np.zeros((3, 2, 2))
     data_tensor = to_torch(data_array[[]])
     assert isinstance(data_tensor, torch.Tensor)

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -29,6 +29,10 @@ def test_batch():
     assert b.a == 3
     with pytest.raises(AssertionError):
         Batch({1: 2})
+    with pytest.raises(TypeError):
+        Batch(a=[np.zeros((2, 3)), np.zeros((3, 3))])
+    with pytest.raises(TypeError):
+        Batch(a=[torch.zeros((2, 3)), torch.zeros((3, 3))])
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
     assert torch.allclose(batch.a, torch.ones(2, 3))
     batch = Batch(obs=[0], np=np.zeros([3, 4]))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -32,6 +32,8 @@ def test_batch():
     with pytest.raises(TypeError):
         Batch(a=[np.zeros((2, 3)), np.zeros((3, 3))])
     with pytest.raises(TypeError):
+        Batch(a=[np.zeros((3, 2)), np.zeros((3, 3))])
+    with pytest.raises(TypeError):
         Batch(a=[torch.zeros((2, 3)), torch.zeros((3, 3))])
     batch = Batch(a=[torch.ones(3), torch.ones(3)])
     assert torch.allclose(batch.a, torch.ones(2, 3))

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -347,10 +347,13 @@ def test_utils_to_torch_numpy():
     data_list_5_torch = to_torch(data_list_5)
     assert isinstance(data_list_5_torch, list)
     assert all(isinstance(e, torch.Tensor) for e in data_list_5_torch)
-    data_array = np.zeros((3, 2, 2))
-    data_tensor = to_torch(data_array[[]])
-    assert isinstance(data_tensor, torch.Tensor)
-    assert data_tensor.shape == (0, 2, 2)
+    data_array = np.random.rand(3, 2, 2)
+    data_empty_tensor = to_torch(data_array[[]])
+    assert isinstance(data_empty_tensor, torch.Tensor)
+    assert data_empty_tensor.shape == (0, 2, 2)
+    data_empty_array = to_numpy(data_empty_tensor)
+    assert isinstance(data_empty_array, np.ndarray)
+    assert data_empty_array.shape == (0, 2, 2)
     assert np.allclose(to_numpy(to_torch(data_array)), data_array)
 
 

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -323,8 +323,10 @@ def test_utils_to_torch():
     assert batch_torch_float.a.dtype == torch.float32
     assert batch_torch_float.b.c.dtype == torch.float32
     assert batch_torch_float.b.d.dtype == torch.float32
-    array_list = [float('nan'), 1.0]
-    assert to_torch(array_list).dtype == torch.float64
+    data_list = [float('nan'), 1]
+    data_list_torch = to_torch(data_list)
+    assert data_list_torch[0].dtype == torch.float64
+    assert data_list_torch[1].dtype == torch.int64
 
 
 def test_batch_pickle():

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -325,9 +325,22 @@ def test_utils_to_torch():
     assert batch_torch_float.b.d.dtype == torch.float32
     data_list = [float('nan'), 1]
     data_list_torch = to_torch(data_list)
-    assert data_list_torch[0].dtype == torch.float64
-    assert data_list_torch[1].dtype == torch.int64
-
+    assert data_list_torch.dtype == torch.float64
+    data_list_2 = [np.zeros((3, 3)), np.zeros((3, 3))]
+    data_list_2_torch = to_torch(data_list_2)
+    assert data_list_2_torch.shape == (2, 3, 3)
+    data_list_3 = [np.zeros((3, 2)), np.zeros((3, 3))]
+    data_list_3_torch = to_torch(data_list_3)
+    assert isinstance(data_list_3_torch, list)
+    assert isinstance(data_list_3_torch[0], torch.Tensor)
+    data_list_4 = [np.zeros(2), np.zeros((3, 3))]
+    data_list_4_torch = to_torch(data_list_4)
+    assert isinstance(data_list_4_torch, list)
+    assert isinstance(data_list_4_torch[0], torch.Tensor)
+    data_array = np.zeros((3, 2, 2))
+    data_tensor = to_torch(data_array[[]])
+    assert isinstance(data_tensor, torch.Tensor)
+    assert data_tensor.shape == (0, 2, 2)
 
 def test_batch_pickle():
     batch = Batch(obs=Batch(a=0.0, c=torch.Tensor([1.0, 2.0])),

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 from itertools import starmap
 
-from tianshou.data import Batch, to_torch
+from tianshou.data import Batch, to_torch, to_numpy
 
 
 def test_batch():

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -53,16 +53,19 @@ def _is_number(value: Any) -> bool:
 def _to_array_with_correct_type(v: Any) -> np.ndarray:
     # convert the value to np.ndarray
     # convert to np.object data type if neither bool nor number
-    v = np.asanyarray(v)
-    if not issubclass(v.dtype.type, (np.bool_, np.number)):
-        v = v.astype(np.object)
-    if v.dtype == np.object and not v.shape:
-        # scalar ndarray with np.object data type is very annoying
-        # a=np.array([np.array({}, dtype=object), np.array({}, dtype=object)])
-        # a is not array([{}, {}], dtype=object), and a[0]={} results in
-        # something very strange:
-        # array([{}, array({}, dtype=object)], dtype=object)
-        v = v.item(0)
+    try:
+        v = np.asanyarray(v)
+        if not issubclass(v.dtype.type, (np.bool_, np.number)):
+            v = v.astype(np.object)
+        if v.dtype == np.object and not v.shape:
+            # scalar ndarray with np.object data type is very annoying
+            # a=np.array([np.array({}, dtype=object), np.array({}, dtype=object)])
+            # a is not array([{}, {}], dtype=object), and a[0]={} results in
+            # something very strange:
+            # array([{}, array({}, dtype=object)], dtype=object)
+            v = v.item(0)
+    except ValueError:
+        pass
     return v
 
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -69,7 +69,8 @@ def _to_array_with_correct_type(v: Any) -> np.ndarray:
         # array([{}, array({}, dtype=object)], dtype=object)
         if not v.shape:
             v = v.item(0)
-        elif any(isinstance(e, (np.ndarray, torch.Tensor)) for e in v):
+        elif any(isinstance(e, (np.ndarray, torch.Tensor))
+                 for e in v.reshape(-1)):
             raise ValueError("Numpy arrays of tensors are not supported yet.")
     return v
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -69,7 +69,7 @@ def _to_array_with_correct_type(v: Any) -> np.ndarray:
         # array([{}, array({}, dtype=object)], dtype=object)
         if not v.shape:
             v = v.item(0)
-        elif isinstance(v.item(0), (np.ndarray, torch.Tensor)):
+        elif any(isinstance(e, (np.ndarray, torch.Tensor)) for e in v):
             raise ValueError("Numpy arrays of tensors are not supported yet.")
     return v
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -52,6 +52,8 @@ def _is_number(value: Any) -> bool:
 
 def _to_array_with_correct_type(v: Any) -> np.ndarray:
     # convert the value to np.ndarray
+    # convert to np.object data type if neither bool nor number
+    # raises an exception if array's elements are tensors themself
     v = np.asanyarray(v)
     if not issubclass(v.dtype.type, (np.bool_, np.number)):
         v = v.astype(np.object)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -131,15 +131,13 @@ def _parse_value(v: Any):
             try:
                 return torch.stack(v)
             except RuntimeError as e:
-                raise Exception([
-                    TypeError("Batch does not support non-stackable list/tuple "
-                              "of torch.Tensor as unique value yet."), e])
+                raise TypeError("Batch does not support non-stackable list/tuple "
+                                "of torch.Tensor as unique value yet.") from e
         try:
             v_ = _to_array_with_correct_type(v)
         except ValueError as e:
-            raise Exception([
-                TypeError("Batch does not support heterogeneous list/tuple "
-                          "of tensors as unique value yet."), e])
+            raise TypeError("Batch does not support heterogeneous list/tuple "
+                             "of tensors as unique value yet.") from e
         if _is_batch_set(v):
             v = Batch(v)  # list of dict / Batch
         else:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -55,13 +55,16 @@ def _to_array_with_correct_type(v: Any) -> np.ndarray:
     v = np.asanyarray(v)
     if not issubclass(v.dtype.type, (np.bool_, np.number)):
         v = v.astype(np.object)
-    if v.dtype == np.object and not v.shape:
+    if v.dtype == np.object:
         # scalar ndarray with np.object data type is very annoying
         # a=np.array([np.array({}, dtype=object), np.array({}, dtype=object)])
         # a is not array([{}, {}], dtype=object), and a[0]={} results in
         # something very strange:
         # array([{}, array({}, dtype=object)], dtype=object)
-        v = v.item(0)
+        if not v.shape:
+            v = v.item(0)
+        elif isinstance(v.item(0), (np.ndarray, torch.Tensor)):
+            raise ValueError("Numpy arrays of tensors are not supported yet.")
     return v
 
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -125,7 +125,10 @@ def _parse_value(v: Any):
                 # or actually a data list with objects
                 v = v_
         except ValueError:
-            v = [_to_array_with_correct_type(e) for e in v]
+            v_ = np.empty(len(v), dtype=np.object)
+            for i, e in enumerate(v):
+                v_[i] = _to_array_with_correct_type(e)
+            v = v_
     elif isinstance(v, dict):
         v = Batch(v)
     elif isinstance(v, (Batch, torch.Tensor)):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -134,9 +134,9 @@ def _parse_value(v: Any):
                 # None, scalar, normal data list (main case)
                 # or an actual list of objects
                 v = v_
-        except (ValueError, RuntimeError):
+        except (ValueError, RuntimeError) as e:
             raise TypeError("Batch does not support non-stackable list/tuple "
-                            "of tensors as value yet.")
+                            "of tensors as value yet: \n" + str(e))
     return v
 
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -37,11 +37,11 @@ def _is_scalar(value: Any) -> bool:
     # 3. python object rather than dict / Batch / tensor
     # the check of dict / Batch is omitted because this only checks a value.
     # a dict / Batch will eventually check their values
-    if isinstance(value, (np.ndarray, torch.Tensor)):
-        return value.size == 1 and not value.shape
+    if isinstance(value, torch.Tensor):
+        return value.numel() == 1 and not value.shape
     else:
         value = np.asanyarray(value)
-        return _is_scalar(value)
+        return value.size == 1 and not value.shape
 
 
 def _is_number(value: Any) -> bool:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -127,7 +127,10 @@ def _parse_value(v: Any):
         except (ValueError, RuntimeError):
             v_ = np.empty(len(v), dtype=np.object)
             for i, e in enumerate(v):
-                v_[i] = _to_array_with_correct_type(e)
+                if not isinstance(e, torch.Tensor):
+                    v_[i] = _to_array_with_correct_type(e)
+                else:
+                    v_[i] = e
             v = v_
     elif isinstance(v, dict):
         v = Batch(v)

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -52,20 +52,16 @@ def _is_number(value: Any) -> bool:
 
 def _to_array_with_correct_type(v: Any) -> np.ndarray:
     # convert the value to np.ndarray
-    # convert to np.object data type if neither bool nor number
-    try:
-        v = np.asanyarray(v)
-        if not issubclass(v.dtype.type, (np.bool_, np.number)):
-            v = v.astype(np.object)
-        if v.dtype == np.object and not v.shape:
-            # scalar ndarray with np.object data type is very annoying
-            # a=np.array([np.array({}, dtype=object), np.array({}, dtype=object)])
-            # a is not array([{}, {}], dtype=object), and a[0]={} results in
-            # something very strange:
-            # array([{}, array({}, dtype=object)], dtype=object)
-            v = v.item(0)
-    except ValueError:
-        pass
+    v = np.asanyarray(v)
+    if not issubclass(v.dtype.type, (np.bool_, np.number)):
+        v = v.astype(np.object)
+    if v.dtype == np.object and not v.shape:
+        # scalar ndarray with np.object data type is very annoying
+        # a=np.array([np.array({}, dtype=object), np.array({}, dtype=object)])
+        # a is not array([{}, {}], dtype=object), and a[0]={} results in
+        # something very strange:
+        # array([{}, array({}, dtype=object)], dtype=object)
+        v = v.item(0)
     return v
 
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -37,8 +37,11 @@ def _is_scalar(value: Any) -> bool:
     # 3. python object rather than dict / Batch / tensor
     # the check of dict / Batch is omitted because this only checks a value.
     # a dict / Batch will eventually check their values
-    value = np.asanyarray(value)
-    return value.size == 1 and not value.shape
+    if isinstance(value, (np.ndarray, torch.Tensor)):
+        return value.size == 1 and not value.shape
+    else:
+        value = np.asanyarray(value)
+        return _is_scalar(value)
 
 
 def _is_number(value: Any) -> bool:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -128,11 +128,11 @@ def _parse_value(v: Any):
                     all(isinstance(e, torch.Tensor) for e in v):
                 return torch.stack(v)
             v_ = _to_array_with_correct_type(v)
-            if v_.dtype == np.object and _is_batch_set(v):
+            if _is_batch_set(v):
                 v = Batch(v)  # list of dict / Batch
             else:
-                # scalar case, normal data list (main case)
-                # or actually a data list with objects
+                # None, scalar, normal data list (main case)
+                # or an actual list of objects
                 v = v_
         except (ValueError, RuntimeError):
             raise TypeError("Batch does not support non-stackable list/tuple "

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -131,13 +131,13 @@ def _parse_value(v: Any):
             try:
                 return torch.stack(v)
             except RuntimeError as e:
-                raise TypeError("Batch does not support non-stackable list/tuple "
-                                "of torch.Tensor as unique value yet.") from e
+                raise TypeError("Batch does not support non-stackable iterable"
+                                " of torch.Tensor as unique value yet.") from e
         try:
             v_ = _to_array_with_correct_type(v)
         except ValueError as e:
-            raise TypeError("Batch does not support heterogeneous list/tuple "
-                             "of tensors as unique value yet.") from e
+            raise TypeError("Batch does not support heterogeneous list/tuple"
+                            " of tensors as unique value yet.") from e
         if _is_batch_set(v):
             v = Batch(v)  # list of dict / Batch
         else:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 from copy import deepcopy
 from numbers import Number
-from collections.abc import Iterable
+from collections.abc import Collection
 from typing import Any, List, Tuple, Union, Iterator, Optional
 
 # Disable pickle warning related to torch, since it has been removed
@@ -126,8 +126,8 @@ def _parse_value(v: Any):
     elif isinstance(v, (Batch, torch.Tensor)):
         pass
     else:
-        if not isinstance(v, np.ndarray) and isinstance(v, Iterable) and \
-                all(isinstance(e, torch.Tensor) for e in v):
+        if not isinstance(v, np.ndarray) and isinstance(v, Collection) and \
+                len(v) > 0 and all(isinstance(e, torch.Tensor) for e in v):
             try:
                 return torch.stack(v)
             except RuntimeError as e:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -128,8 +128,8 @@ def _parse_value(v: Any):
                 # or actually a data list with objects
                 v = v_
         except (ValueError, RuntimeError):
-            raise TypeError("Batch does not support non-stackable list/tuple of "\
-                            "tensors as value yet.")
+            raise TypeError("Batch does not support non-stackable list/tuple "
+                            "of tensors as value yet.")
     elif isinstance(v, dict):
         v = Batch(v)
     elif isinstance(v, (Batch, torch.Tensor)):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -115,15 +115,17 @@ def _parse_value(v: Any):
     if isinstance(v, (list, tuple, np.ndarray)):
         if not isinstance(v, np.ndarray) and \
                 all(isinstance(e, torch.Tensor) for e in v):
-            v = torch.stack(v)
-            return v
-        v_ = _to_array_with_correct_type(v)
-        if v_.dtype == np.object and _is_batch_set(v):
-            v = Batch(v)  # list of dict / Batch
-        else:
-            # normal data list (main case)
-            # or actually a data list with objects
-            v = v_
+            return torch.stack(v)
+        try:
+            v_ = _to_array_with_correct_type(v)
+            if v_.dtype == np.object and _is_batch_set(v):
+                v = Batch(v)  # list of dict / Batch
+            else:
+                # normal data list (main case)
+                # or actually a data list with objects
+                v = v_
+        except ValueError:
+            v = [_to_array_with_correct_type(e) for e in v]
     elif isinstance(v, dict):
         v = Batch(v)
     elif isinstance(v, (Batch, torch.Tensor)):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -125,13 +125,8 @@ def _parse_value(v: Any):
                 # or actually a data list with objects
                 v = v_
         except (ValueError, RuntimeError):
-            v_ = np.empty(len(v), dtype=np.object)
-            for i, e in enumerate(v):
-                if not isinstance(e, torch.Tensor):
-                    v_[i] = _to_array_with_correct_type(e)
-                else:
-                    v_[i] = e
-            v = v_
+            raise TypeError("Batch does not support non-stackable list/tuple of "\
+                            "tensors as value yet.")
     elif isinstance(v, dict):
         v = Batch(v)
     elif isinstance(v, (Batch, torch.Tensor)):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -113,10 +113,10 @@ def _assert_type_keys(keys):
 
 def _parse_value(v: Any):
     if isinstance(v, (list, tuple, np.ndarray)):
-        if not isinstance(v, np.ndarray) and \
-                all(isinstance(e, torch.Tensor) for e in v):
-            return torch.stack(v)
         try:
+            if not isinstance(v, np.ndarray) and \
+                    all(isinstance(e, torch.Tensor) for e in v):
+                return torch.stack(v)
             v_ = _to_array_with_correct_type(v)
             if v_.dtype == np.object and _is_batch_set(v):
                 v = Batch(v)  # list of dict / Batch
@@ -124,7 +124,7 @@ def _parse_value(v: Any):
                 # normal data list (main case)
                 # or actually a data list with objects
                 v = v_
-        except ValueError:
+        except (ValueError, RuntimeError):
             v_ = np.empty(len(v), dtype=np.object)
             for i, e in enumerate(v):
                 v_[i] = _to_array_with_correct_type(e)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -19,6 +19,8 @@ def to_numpy(x: Union[
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
         x = [to_numpy(x_i) for x_i in x]
+    else: # fallback
+        x = np.asanyarray(x)
     return x
 
 
@@ -40,11 +42,14 @@ def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
         x = [to_torch(x_i, dtype, device) for x_i in x]
-    elif isinstance(x, np.ndarray) and \
-            isinstance(x.item(0), (np.number, np.bool_, Number)):
-        x = torch.from_numpy(x).to(device)
-        if dtype is not None:
-            x = x.type(dtype)
+    else: # fallback
+        x = np.asanyarray(x)
+        if isinstance(x.item(0), (np.number, np.bool_, Number)):
+            x = torch.from_numpy(x).to(device)
+            if dtype is not None:
+                x = x.type(dtype)
+        else:
+            raise TypeError(f"object {x} cannot be converted to torch.")
     return x
 
 

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -45,7 +45,10 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
-        x = _to_array_with_correct_type(x)
+        try:
+            x = _to_array_with_correct_type(x)
+        except ValueError:
+            pass
         if x.dtype == np.object:
             x = [to_torch(e, dtype, device) for e in x]
         else:

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -19,7 +19,7 @@ def to_numpy(x: Union[
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
         x = _parse_value(x)
-        if isinstance(x, (list, tuple)) or x.dtype == np.object:
+        if x.dtype == np.object:
             x = [to_numpy(e) for e in x]
         else:
             x = to_numpy(x)
@@ -46,7 +46,7 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
         x = _parse_value(x)
-        if isinstance(x, (list, tuple)) or x.dtype == np.object:
+        if x.dtype == np.object:
             x = [to_torch(e, dtype, device) for e in x]
         else:
             x = to_torch(x, dtype, device)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 from numbers import Number
-from typing import Any, Union, Optional
+from typing import Union, Optional
 
 from tianshou.data.batch import _parse_value, Batch
 

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -7,8 +7,8 @@ from tianshou.data import Batch
 
 
 def to_numpy(x: Union[
-    torch.Tensor, dict, Batch, np.ndarray]) -> Union[
-        dict, Batch, np.ndarray]:
+    Batch, dict, list, tuple, np.ndarray, torch.Tensor]) -> Union[
+        Batch, dict, list, tuple, np.ndarray, torch.Tensor]:
     """Return an object without torch.Tensor."""
     if isinstance(x, torch.Tensor):
         x = x.detach().cpu().numpy()
@@ -24,10 +24,10 @@ def to_numpy(x: Union[
     return x
 
 
-def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
+def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
              dtype: Optional[torch.dtype] = None,
              device: Union[str, int, torch.device] = 'cpu'
-             ) -> Union[dict, Batch, torch.Tensor]:
+             ) -> Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor]:
     """Return an object without np.ndarray."""
     if isinstance(x, torch.Tensor):
         if dtype is not None:
@@ -44,7 +44,7 @@ def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
         x = [to_torch(x_i, dtype, device) for x_i in x]
     else:  # fallback
         x = np.asanyarray(x)
-        if isinstance(x.item(0), (np.number, np.bool_, Number)):
+        if issubclass(x.dtype.type, (np.bool_, np.number)):
             x = torch.from_numpy(x).to(device)
             if dtype is not None:
                 x = x.type(dtype)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -19,7 +19,7 @@ def to_numpy(x: Union[
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
         x = [to_numpy(x_i) for x_i in x]
-    else: # fallback
+    else:  # fallback
         x = np.asanyarray(x)
     return x
 
@@ -42,7 +42,7 @@ def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
         x = [to_torch(x_i, dtype, device) for x_i in x]
-    else: # fallback
+    else:  # fallback
         x = np.asanyarray(x)
         if isinstance(x.item(0), (np.number, np.bool_, Number)):
             x = torch.from_numpy(x).to(device)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -18,11 +18,10 @@ def to_numpy(x: Union[
     elif isinstance(x, Batch):
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
-        x = _parse_value(x)
-        if x.dtype == np.object:
+        try:
+            x = to_numpy(_parse_value(x))
+        except TypeError:
             x = [to_numpy(e) for e in x]
-        else:
-            x = to_numpy(x)
     else:  # fallback
         x = np.asanyarray(x)
     return x
@@ -45,11 +44,10 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
-        x = _parse_value(x)
-        if x.dtype == np.object:
+        try:
+            x = to_torch(_parse_value(x), dtype, device)
+        except TypeError:
             x = [to_torch(e, dtype, device) for e in x]
-        else:
-            x = to_torch(x, dtype, device)
     else:  # fallback
         x = np.asanyarray(x)
         if issubclass(x.dtype.type, (np.bool_, np.number)):

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -17,6 +17,8 @@ def to_numpy(x: Union[
             x[k] = to_numpy(v)
     elif isinstance(x, Batch):
         x.to_numpy()
+    elif isinstance(x, (list, tuple)):
+        x = [to_numpy(x_i) for x_i in x]
     return x
 
 
@@ -36,9 +38,8 @@ def to_torch(x: Union[torch.Tensor, dict, Batch, np.ndarray],
         x.to_torch(dtype, device)
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
-    elif isinstance(x, list) and len(x) > 0 and \
-            all(isinstance(e, (np.number, np.bool_, Number)) for e in x):
-        x = to_torch(np.asanyarray(x), dtype, device)
+    elif isinstance(x, (list, tuple)):
+        x = [to_torch(x_i, dtype, device) for x_i in x]
     elif isinstance(x, np.ndarray) and \
             isinstance(x.item(0), (np.number, np.bool_, Number)):
         x = torch.from_numpy(x).to(device)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 from numbers import Number
 from typing import Any, Union, Optional
 
-from tianshou.data.batch import _to_array_with_correct_type, Batch
+from tianshou.data.batch import _parse_value, Batch
 
 
 def to_numpy(x: Union[
@@ -18,8 +18,8 @@ def to_numpy(x: Union[
     elif isinstance(x, Batch):
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
-        x = _to_array_with_correct_type(x)
-        if x.dtype == np.object:
+        x = _parse_value(x)
+        if isinstance(x, (list, tuple)) or x.dtype == np.object:
             x = [to_numpy(e) for e in x]
         else:
             x = to_numpy(x)
@@ -45,11 +45,8 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
-        try:
-            x = _to_array_with_correct_type(x)
-        except ValueError:
-            pass
-        if x.dtype == np.object:
+        x = _parse_value(x)
+        if isinstance(x, (list, tuple)) or x.dtype == np.object:
             x = [to_torch(e, dtype, device) for e in x]
         else:
             x = to_torch(x, dtype, device)

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -18,7 +18,11 @@ def to_numpy(x: Union[
     elif isinstance(x, Batch):
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
-        x = [to_numpy(x_i) for x_i in x]
+        x = np.asanyarray(x)
+        if x.dtype == np.object:
+            x = [to_numpy(e) for e in x]
+        else:
+            x = to_numpy(x)
     else:  # fallback
         x = np.asanyarray(x)
     return x
@@ -41,7 +45,11 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
-        x = [to_torch(x_i, dtype, device) for x_i in x]
+        x = np.asanyarray(x)
+        if x.dtype == np.object:
+            x = [to_torch(e, dtype, device) for e in x]
+        else:
+            x = to_torch(x, dtype, device)
     else:  # fallback
         x = np.asanyarray(x)
         if issubclass(x.dtype.type, (np.bool_, np.number)):

--- a/tianshou/data/utils.py
+++ b/tianshou/data/utils.py
@@ -1,9 +1,9 @@
 import torch
 import numpy as np
 from numbers import Number
-from typing import Union, Optional
+from typing import Any, Union, Optional
 
-from tianshou.data import Batch
+from tianshou.data.batch import _to_array_with_correct_type, Batch
 
 
 def to_numpy(x: Union[
@@ -18,7 +18,7 @@ def to_numpy(x: Union[
     elif isinstance(x, Batch):
         x.to_numpy()
     elif isinstance(x, (list, tuple)):
-        x = np.asanyarray(x)
+        x = _to_array_with_correct_type(x)
         if x.dtype == np.object:
             x = [to_numpy(e) for e in x]
         else:
@@ -45,7 +45,7 @@ def to_torch(x: Union[Batch, dict, list, tuple, np.ndarray, torch.Tensor],
     elif isinstance(x, (np.number, np.bool_, Number)):
         x = to_torch(np.asanyarray(x), dtype, device)
     elif isinstance(x, (list, tuple)):
-        x = np.asanyarray(x)
+        x = _to_array_with_correct_type(x)
         if x.dtype == np.object:
             x = [to_torch(e, dtype, device) for e in x]
         else:


### PR DESCRIPTION
- Do not force cast `list` and `tuple`.
- Do not silently skip cast if no converter is found
- Add fallback for `to_numpy`