### PR TITLE
unify single-env and multi-env in collector

### DIFF
--- a/docs/tutorials/concepts.rst
+++ b/docs/tutorials/concepts.rst
@@ -130,7 +130,7 @@ In short, :class:`~tianshou.data.Collector` has two main methods:
 * :meth:`~tianshou.data.Collector.collect`: let the policy perform (at least) a specified number of step ``n_step`` or episode ``n_episode`` and store the data in the replay buffer;
 * :meth:`~tianshou.data.Collector.sample`: sample a data batch from replay buffer; it will call :meth:`~tianshou.policy.BasePolicy.process_fn` before returning the final batch data.
 
-Why do we mention **at least** here? For a single environment, the collector will finish exactly ``n_step`` or ``n_episode``. However, for multiple environments, we could not directly store the collected data into the replay buffer, since it breaks the principle of storing data chronologically.
+Why do we mention **at least** here? For multiple environments, we could not directly store the collected data into the replay buffer, since it breaks the principle of storing data chronologically.
 
 The solution is to add some cache buffers inside the collector. Once collecting **a full episode of trajectory**, it will move the stored data from the cache buffer to the main buffer. To satisfy this condition, the collector will interact with environments that may exceed the given step number or episode number.
 

--- a/docs/tutorials/dqn.rst
+++ b/docs/tutorials/dqn.rst
@@ -179,7 +179,7 @@ Train a Policy with Customized Codes
 Tianshou supports user-defined training code. Here is the code snippet:
 ::
 
-    # pre-collect 5000 frames with random action before training
+    # pre-collect at least 5000 frames with random action before training
     policy.set_eps(1)
     train_collector.collect(n_step=5000)
 

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -98,7 +98,7 @@ def test_collector_with_dict_state():
     policy = MyPolicy(dict_state=True)
     c0 = Collector(policy, env, ReplayBuffer(size=100), preprocess_fn)
     c0.collect(n_step=3)
-    c0.collect(n_episode=3)
+    c0.collect(n_episode=2)
     env_fns = [lambda x=i: MyTestEnv(size=x, sleep=0, dict_state=True)
                for i in [2, 3, 4, 5]]
     envs = VectorEnv(env_fns)
@@ -126,9 +126,10 @@ def test_collector_with_ma():
     policy = MyPolicy()
     c0 = Collector(policy, env, ReplayBuffer(size=100),
                    preprocess_fn, reward_metric=reward_metric)
+    # n_step=3 will collect a full episode
     r = c0.collect(n_step=3)['rew']
-    assert np.asanyarray(r).size == 1 and r == 0.
-    r = c0.collect(n_episode=3)['rew']
+    assert np.asanyarray(r).size == 1 and r == 4.
+    r = c0.collect(n_episode=2)['rew']
     assert np.asanyarray(r).size == 1 and r == 4.
     env_fns = [lambda x=i: MyTestEnv(size=x, sleep=0, ma_rew=4)
                for i in [2, 3, 4, 5]]

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -72,11 +72,11 @@ def test_collector():
     c0 = Collector(policy, env, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c0.collect(n_step=3)
-    assert np.allclose(c0.buffer.obs[:3], [0, 1, 0])
-    assert np.allclose(c0.buffer[:3].obs_next, [1, 2, 1])
+    assert np.allclose(c0.buffer.obs[:4], [0, 1, 0, 1])
+    assert np.allclose(c0.buffer[:4].obs_next, [1, 2, 1, 2])
     c0.collect(n_episode=3)
-    assert np.allclose(c0.buffer.obs[:8], [0, 1, 0, 1, 0, 1, 0, 1])
-    assert np.allclose(c0.buffer[:8].obs_next, [1, 2, 1, 2, 1, 2, 1, 2])
+    assert np.allclose(c0.buffer.obs[:10], [0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+    assert np.allclose(c0.buffer[:10].obs_next, [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
     c0.collect(n_step=3, random=True)
     c1 = Collector(policy, venv, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -75,7 +75,8 @@ class Collector(object):
 
     Collected data always consist of full episodes. So if only ``n_step``
     argument is give, the collector may return the data more than the
-    ``n_step`` limitation.
+    ``n_step`` limitation. Same as ``n_episode`` for the multiple environment
+    case.
 
     .. note::
 
@@ -176,10 +177,10 @@ class Collector(object):
         """Collect a specified number of step or episode.
 
         :param int n_step: how many steps you want to collect.
-        :param n_episode: how many episodes you want to collect. If it is
-            an int, it means to collect at lease ``n_episode`` episodes; if
-            it is list, it means to collect exactly ``n_episode[i]`` episodes
-            in the i-th environment
+        :param n_episode: how many episodes you want to collect. If it is an
+            int, it means to collect at lease ``n_episode`` episodes; if it is
+            a list, it means to collect exactly ``n_episode[i]`` episodes in
+            the i-th environment
         :param bool random: whether to use random policy for collecting data,
             defaults to ``False``.
         :param float render: the sleep time between rendering consecutive
@@ -261,8 +262,7 @@ class Collector(object):
                     if n_step or np.isscalar(n_episode) or \
                             episode_count[i] < n_episode[i]:
                         episode_count[i] += 1
-                        reward_total += np.asarray(
-                            self._cached_buf[i].rew).sum(axis=0)
+                        reward_total += np.sum(self._cached_buf[i].rew, axis=0)
                         step_count += len(self._cached_buf[i])
                         if self.buffer is not None:
                             self.buffer.update(self._cached_buf[i])

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -21,8 +21,7 @@ class Collector(object):
     :param env: a ``gym.Env`` environment or an instance of the
         :class:`~tianshou.env.BaseVectorEnv` class.
     :param buffer: an instance of the :class:`~tianshou.data.ReplayBuffer`
-        class, or a list of :class:`~tianshou.data.ReplayBuffer`. If set to
-        ``None``, it will automatically assign a small-size
+        class. If set to ``None``, it will automatically assign a small-size
         :class:`~tianshou.data.ReplayBuffer`.
     :param function preprocess_fn: a function called before the data has been
         added to the buffer, see issue #42 and :ref:`preprocess_fn`, defaults
@@ -56,9 +55,6 @@ class Collector(object):
 
         # the collector supports vectorized environments as well
         envs = VectorEnv([lambda: gym.make('CartPole-v0') for _ in range(3)])
-        buffers = [ReplayBuffer(size=5000) for _ in range(3)]
-        # you can also pass a list of replay buffer to collector, for multi-env
-        # collector = Collector(policy, envs, buffer=buffers)
         collector = Collector(policy, envs, buffer=replay_buffer)
 
         # collect at least 3 episodes
@@ -81,9 +77,9 @@ class Collector(object):
         #   clear the buffer
         collector.reset_buffer()
 
-    For the scenario of collecting data from multiple environments to a single
-    buffer, the cache buffers will turn on automatically. It may return the
-    data more than the given limitation.
+    Collected data always consist of full episodes. So if only ``n_step``
+    argument is give, the collector may return the data more than the
+    ``n_step`` limitation.
 
     .. note::
 

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -21,8 +21,7 @@ class Collector(object):
     :param env: a ``gym.Env`` environment or an instance of the
         :class:`~tianshou.env.BaseVectorEnv` class.
     :param buffer: an instance of the :class:`~tianshou.data.ReplayBuffer`
-        class. If set to ``None``, it will automatically assign a small-size
-        :class:`~tianshou.data.ReplayBuffer`.
+        class. If set to ``None`` (testing phase), it will not store the data.
     :param function preprocess_fn: a function called before the data has been
         added to the buffer, see issue #42 and :ref:`preprocess_fn`, defaults
         to ``None``.
@@ -57,7 +56,7 @@ class Collector(object):
         envs = VectorEnv([lambda: gym.make('CartPole-v0') for _ in range(3)])
         collector = Collector(policy, envs, buffer=replay_buffer)
 
-        # collect at least 3 episodes
+        # collect 3 episodes
         collector.collect(n_episode=3)
         # collect 1 episode for the first env, 3 for the third env
         collector.collect(n_episode=[1, 0, 3])

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -172,13 +172,6 @@ class Collector(object):
         """Close the environment(s)."""
         self.env.close()
 
-    def _make_batch(self, data: Any) -> np.ndarray:
-        """Return [data]."""
-        if isinstance(data, np.ndarray):
-            return data[None]
-        else:
-            return np.array([data])
-
     def _reset_state(self, id: Union[int, List[int]]) -> None:
         """Reset self.data.state[id]."""
         state = self.data.state  # it is a reference
@@ -243,11 +236,8 @@ class Collector(object):
 
             # calculate the next action
             if random:
-                action_space = self.env.action_space
-                if isinstance(action_space, list):
-                    result = Batch(act=[a.sample() for a in action_space])
-                else:
-                    result = Batch(act=self._make_batch(action_space.sample()))
+                result = Batch(
+                    act=[a.sample() for a in self.env.action_space])
             else:
                 with torch.no_grad():
                     result = self.policy(self.data, last_state)

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -286,13 +286,11 @@ class Collector(object):
                         cur_episode[i] += 1
                         reward_sum += self.reward[i]
                         length_sum += self.length[i]
-                        if self._cached_buf:
-                            cur_step += len(self._cached_buf[i])
-                            if self.buffer is not None:
-                                self.buffer.update(self._cached_buf[i])
+                        cur_step += len(self._cached_buf[i])
+                        if self.buffer is not None:
+                            self.buffer.update(self._cached_buf[i])
                     self.reward[i], self.length[i] = 0., 0
-                    if self._cached_buf:
-                        self._cached_buf[i].reset()
+                    self._cached_buf[i].reset()
                     self._reset_state(i)
             obs_next = self.data.obs_next
             if sum(self.data.done):

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -101,7 +101,7 @@ class Collector(object):
                  ) -> None:
         super().__init__()
         if not isinstance(env, BaseVectorEnv):
-            env = VectorEnv([lambda : env])
+            env = VectorEnv([lambda: env])
         self.env = env
         self.env_num = len(env)
         # need cache buffers before storing in the main buffer

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -97,6 +97,7 @@ class Collector(object):
         self.env_num = len(env)
         # need cache buffers before storing in the main buffer
         self._cached_buf = [ListReplayBuffer() for _ in range(self.env_num)]
+        self.collect_time, self.collect_step, self.collect_episode = 0., 0, 0
         self.buffer = buffer
         self.policy = policy
         self.preprocess_fn = preprocess_fn
@@ -120,6 +121,7 @@ class Collector(object):
                           obs_next={}, policy={})
         self.reset_env()
         self.reset_buffer()
+        self.collect_time, self.collect_step, self.collect_episode = 0., 0, 0
         if self._action_noise is not None:
             self._action_noise.reset()
 
@@ -298,6 +300,9 @@ class Collector(object):
         # generate the statistics
         cur_episode = sum(cur_episode)
         duration = max(time.time() - start_time, 1e-9)
+        self.collect_step += cur_step
+        self.collect_episode += cur_episode
+        self.collect_time += duration
         if isinstance(n_episode, list):
             n_episode = np.sum(n_episode)
         else:

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -178,9 +178,9 @@ class Collector(object):
 
         :param int n_step: how many steps you want to collect.
         :param n_episode: how many episodes you want to collect. If it is
-            an int, it means to collect totally ``n_episode`` episodes; if
-            it is a list, it means to collect ``n_episode[i]`` episodes in
-            the i-th environment
+            an int, it means to collect at lease ``n_episode`` episodes; if
+            it is list, it means to collect exactly ``n_episode[i]`` episodes
+            in the i-th environment
         :param bool random: whether to use random policy for collecting data,
             defaults to ``False``.
         :param float render: the sleep time between rendering consecutive
@@ -254,8 +254,7 @@ class Collector(object):
                 log_fn(self.data.info)
             if render:
                 self.render()
-                if render > 0:
-                    time.sleep(render)
+                time.sleep(render)
 
             # add data into the buffer
             if self.preprocess_fn:
@@ -283,17 +282,17 @@ class Collector(object):
                         obs=obs_reset).get('obs', obs_reset)
                 else:
                     obs_next[env_ind] = obs_reset
-            self.data.obs_next = obs_next
-            if n_episode:
-                if isinstance(n_episode, list) and \
-                        (episode_count >= np.array(n_episode)).all() or \
-                        np.isscalar(n_episode) and \
+            self.data.obs = obs_next
+            if n_step:
+                if step_count >= n_step:
+                    break
+            else:
+                if isinstance(n_episode, int) and \
                         episode_count.sum() >= n_episode:
                     break
-            if n_step and step_count >= n_step:
-                break
-            self.data.obs = self.data.obs_next
-        self.data.obs = self.data.obs_next
+                if isinstance(n_episode, list) and \
+                        (episode_count >= n_episode).all():
+                    break
 
         # generate the statistics
         episode_count = sum(episode_count)

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -105,8 +105,7 @@ class Collector(object):
         self.env = env
         self.env_num = len(env)
         # need cache buffers before storing in the main buffer
-        self._cached_buf = [ListReplayBuffer()
-                            for _ in range(self.env_num)]
+        self._cached_buf = [ListReplayBuffer() for _ in range(self.env_num)]
         self.collect_time, self.collect_step, self.collect_episode = 0., 0, 0
         self.buffer = buffer
         self.policy = policy
@@ -260,10 +259,7 @@ class Collector(object):
             obs_next, rew, done, info = self.env.step(self.data.act)
 
             # move data to self.data
-            self.data.obs_next = obs_next
-            self.data.rew = rew
-            self.data.done = done
-            self.data.info = info
+            self.data.update(obs_next=obs_next, rew=rew, done=done, info=info)
 
             if log_fn:
                 log_fn(self.data.info)

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -172,7 +172,6 @@ class Collector(object):
                 n_episode: Optional[Union[int, List[int]]] = None,
                 random: bool = False,
                 render: Optional[float] = None,
-                log_fn: Optional[Callable[[dict], None]] = None
                 ) -> Dict[str, float]:
         """Collect a specified number of step or episode.
 
@@ -185,8 +184,6 @@ class Collector(object):
             defaults to ``False``.
         :param float render: the sleep time between rendering consecutive
             frames, defaults to ``None`` (no rendering).
-        :param function log_fn: a function which receives env info, typically
-            for tensorboard logging.
 
         .. note::
 
@@ -250,8 +247,6 @@ class Collector(object):
             # move data to self.data
             self.data.update(obs_next=obs_next, rew=rew, done=done, info=info)
 
-            if log_fn:
-                log_fn(self.data.info)
             if render:
                 self.render()
                 time.sleep(render)

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -23,7 +23,6 @@ def offpolicy_trainer(
         test_fn: Optional[Callable[[int], None]] = None,
         stop_fn: Optional[Callable[[float], bool]] = None,
         save_fn: Optional[Callable[[BasePolicy], None]] = None,
-        log_fn: Optional[Callable[[dict], None]] = None,
         writer: Optional[SummaryWriter] = None,
         log_interval: int = 1,
         verbose: bool = True,
@@ -61,7 +60,6 @@ def offpolicy_trainer(
     :param function stop_fn: a function receives the average undiscounted
         returns of the testing result, return a boolean which indicates whether
         reaching the goal.
-    :param function log_fn: a function receives env info for logging.
     :param torch.utils.tensorboard.SummaryWriter writer: a TensorBoard
         SummaryWriter.
     :param int log_interval: the log interval of the writer.
@@ -83,8 +81,7 @@ def offpolicy_trainer(
         with tqdm.tqdm(total=step_per_epoch, desc=f'Epoch #{epoch}',
                        **tqdm_config) as t:
             while t.n < t.total:
-                result = train_collector.collect(n_step=collect_per_step,
-                                                 log_fn=log_fn)
+                result = train_collector.collect(n_step=collect_per_step)
                 data = {}
                 if test_in_train and stop_fn and stop_fn(result['rew']):
                     test_result = test_episode(

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -23,7 +23,6 @@ def onpolicy_trainer(
         test_fn: Optional[Callable[[int], None]] = None,
         stop_fn: Optional[Callable[[float], bool]] = None,
         save_fn: Optional[Callable[[BasePolicy], None]] = None,
-        log_fn: Optional[Callable[[dict], None]] = None,
         writer: Optional[SummaryWriter] = None,
         log_interval: int = 1,
         verbose: bool = True,
@@ -62,7 +61,6 @@ def onpolicy_trainer(
     :param function stop_fn: a function receives the average undiscounted
         returns of the testing result, return a boolean which indicates whether
         reaching the goal.
-    :param function log_fn: a function receives env info for logging.
     :param torch.utils.tensorboard.SummaryWriter writer: a TensorBoard
         SummaryWriter.
     :param int log_interval: the log interval of the writer.
@@ -84,8 +82,7 @@ def onpolicy_trainer(
         with tqdm.tqdm(total=step_per_epoch, desc=f'Epoch #{epoch}',
                        **tqdm_config) as t:
             while t.n < t.total:
-                result = train_collector.collect(n_episode=collect_per_step,
-                                                 log_fn=log_fn)
+                result = train_collector.collect(n_episode=collect_per_step)
                 data = {}
                 if test_in_train and stop_fn and stop_fn(result['rew']):
                     test_result = test_episode(


### PR DESCRIPTION
Unify the implementation with multi-environments (wrap a single environment in a multi-environment with one envs) to greatly simplify the code.

This changed the behavior of single-environment.
Prior to this pr, for single environment, ``collector.collect(n_step=n)`` will step n steps.
After this pr, for single environment, ``collector.collect(n_step=n)`` will step m episodes until the steps are greater than n.

That is to say, collectors now always collect **full episodes**.