### PR TITLE
ShmemVectorEnv Implementation

### DIFF
--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -31,7 +31,7 @@ See :ref:`customized_trainer`.
 Parallel Sampling
 -----------------
 
-Use :class:`~tianshou.env.VectorEnv` or :class:`~tianshou.env.SubprocVectorEnv`.
+Use :class:`~tianshou.env.VectorEnv`, :class:`~tianshou.env.SubprocVectorEnv` or :class:`~tianshou.env.ShmemVectorEnv`.
 ::
 
     env_fns = [

--- a/docs/tutorials/dqn.rst
+++ b/docs/tutorials/dqn.rst
@@ -30,7 +30,7 @@ It is available if you want the original ``gym.Env``:
     train_envs = gym.make('CartPole-v0')
     test_envs = gym.make('CartPole-v0')
 
-Tianshou supports parallel sampling for all algorithms. It provides three types of vectorized environment wrapper: :class:`~tianshou.env.VectorEnv`, :class:`~tianshou.env.SubprocVectorEnv`, and :class:`~tianshou.env.RayVectorEnv`. It can be used as follows: 
+Tianshou supports parallel sampling for all algorithms. It provides four types of vectorized environment wrapper: :class:`~tianshou.env.VectorEnv`, :class:`~tianshou.env.SubprocVectorEnv`, :class:`~tianshou.env.ShmemVectorEnv`, and :class:`~tianshou.env.RayVectorEnv`. It can be used as follows: 
 ::
 
     train_envs = ts.env.VectorEnv([lambda: gym.make('CartPole-v0') for _ in range(8)])

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -22,13 +22,13 @@ class MyTestEnv(gym.Env):
         if  dict_state:
             self.observation_space = Dict(
                 {"index": Box(shape=(1, ), low=0, high=size - 1),
-                 "rand": Box(shape=(1,), low=0, high=1)})
+                 "rand": Box(shape=(1,), low=0, high=1, dtype=np.float64)})
         elif recurse_state:
             self.observation_space = Dict(
                 {"index": Box(shape=(1, ), low=0, high=size - 1),
                  "dict": Dict({
-                     "tuple": Tuple((Discrete(2), Box(shape=(2,), low=0, high=1))),
-                     "rand": Box(shape=(1,2), low=0, high=1)})
+                     "tuple": Tuple((Discrete(2), Box(shape=(2,), low=0, high=1, dtype=np.float64))),
+                     "rand": Box(shape=(1,2), low=0, high=1, dtype=np.float64)})
                 })
         else:
             self.observation_space = Box(shape=(1, ), low=0, high=size - 1)
@@ -36,10 +36,11 @@ class MyTestEnv(gym.Env):
             self.action_space = MultiDiscrete([2, 2])
         else:
             self.action_space = Discrete(2)
-        self.reset()
+        self.done = False
+        self.index = 0
 
     def seed(self, seed=0):
-        np.random.seed(seed)
+        self.rng = np.random.RandomState(seed)
 
     def reset(self, state=0):
         self.done = False
@@ -56,13 +57,13 @@ class MyTestEnv(gym.Env):
     def _get_dict_state(self):
         """Generate a dict_state if dict_state is True."""
         if self.dict_state:
-            return {'index': np.array([self.index]), 'rand': np.random.rand()}
+            return {'index': np.array([self.index], dtype=np.float32), 'rand': self.rng.rand(1)}
         elif self.recurse_state:
-            return {'index': np.array([self.index]),
-                    'dict': {"tuple": (1, np.random.rand(2)),
-                             "rand": np.random.rand(1, 2)}}
+            return {'index': np.array([self.index], dtype=np.float32),
+                    'dict': {"tuple": (np.array([1], dtype=np.int64), self.rng.rand(2)),
+                             "rand": self.rng.rand(1, 2)}}
         else:
-            return np.array([self.index])
+            return np.array([self.index], dtype=np.float32)
 
     def step(self, action):
         if self._md_action:

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -21,8 +21,8 @@ class MyTestEnv(gym.Env):
             self.observation_space = Box(shape=(1, ), low=0, high=size - 1)
         else:
             self.observation_space = Dict(
-                {"index": Box(shape=(1, ), low=0, high=size - 1), 
-                "rand": Box(shape = (1,), low=0,high=1)})
+                {"index": Box(shape=(1, ), low=0, high=size - 1),
+                 "rand": Box(shape=(1,), low=0, high=1)})
         if multidiscrete_action:
             self.action_space = MultiDiscrete([2, 2])
         else:

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -2,7 +2,7 @@ import gym
 import time
 import random
 import numpy as np
-from gym.spaces import Discrete, MultiDiscrete, Box
+from gym.spaces import Discrete, MultiDiscrete, Box, Dict
 
 
 class MyTestEnv(gym.Env):
@@ -17,7 +17,12 @@ class MyTestEnv(gym.Env):
         self.dict_state = dict_state
         self.ma_rew = ma_rew
         self._md_action = multidiscrete_action
-        self.observation_space = Box(shape=(1, ), low=0, high=size - 1)
+        if not dict_state:
+            self.observation_space = Box(shape=(1, ), low=0, high=size - 1)
+        else:
+            self.observation_space = Dict(
+                {"index": Box(shape=(1, ), low=0, high=size - 1), 
+                "rand": Box(shape = (1,), low=0,high=1)})
         if multidiscrete_action:
             self.action_space = MultiDiscrete([2, 2])
         else:
@@ -41,8 +46,8 @@ class MyTestEnv(gym.Env):
 
     def _get_dict_state(self):
         """Generate a dict_state if dict_state is True."""
-        return {'index': self.index, 'rand': np.random.rand()} \
-            if self.dict_state else self.index
+        return {'index': np.array([self.index]), 'rand': np.random.rand()} \
+            if self.dict_state else np.array([self.index])
 
     def step(self, action):
         if self._md_action:

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -50,7 +50,7 @@ class MyTestEnv(gym.Env):
     def reset(self, state=0):
         self.done = False
         self.index = state
-        return self._get_dict_state()
+        return self._get_state()
 
     def _get_reward(self):
         """Generate a non-scalar reward if ma_rew is True."""
@@ -59,8 +59,8 @@ class MyTestEnv(gym.Env):
             return [x] * self.ma_rew
         return x
 
-    def _get_dict_state(self):
-        """Generate a dict_state if dict_state is True."""
+    def _get_state(self):
+        """Generate state(observation) of MyTestEnv"""
         if self.dict_state:
             return {'index': np.array([self.index], dtype=np.float32),
                     'rand': self.rng.rand(1)}
@@ -83,13 +83,13 @@ class MyTestEnv(gym.Env):
             time.sleep(sleep_time)
         if self.index == self.size:
             self.done = True
-            return self._get_dict_state(), self._get_reward(), self.done, {}
+            return self._get_state(), self._get_reward(), self.done, {}
         if action == 0:
             self.index = max(self.index - 1, 0)
-            return self._get_dict_state(), self._get_reward(), self.done, \
+            return self._get_state(), self._get_reward(), self.done, \
                 {'key': 1, 'env': self} if self.dict_state else {}
         elif action == 1:
             self.index += 1
             self.done = self.index == self.size
-            return self._get_dict_state(), self._get_reward(), \
+            return self._get_state(), self._get_reward(), \
                 self.done, {'key': 1, 'env': self}

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -11,7 +11,9 @@ class MyTestEnv(gym.Env):
 
     def __init__(self, size, sleep=0, dict_state=False, recurse_state=False,
                  ma_rew=0, multidiscrete_action=False, random_sleep=False):
-        assert not (dict_state and recurse_state), "dict_state and recurse_state cannot both be true"
+        assert not (
+            dict_state and recurse_state), \
+            "dict_state and recurse_state cannot both be true"
         self.size = size
         self.sleep = sleep
         self.random_sleep = random_sleep
@@ -19,7 +21,7 @@ class MyTestEnv(gym.Env):
         self.recurse_state = recurse_state
         self.ma_rew = ma_rew
         self._md_action = multidiscrete_action
-        if  dict_state:
+        if dict_state:
             self.observation_space = Dict(
                 {"index": Box(shape=(1, ), low=0, high=size - 1),
                  "rand": Box(shape=(1,), low=0, high=1, dtype=np.float64)})
@@ -27,9 +29,11 @@ class MyTestEnv(gym.Env):
             self.observation_space = Dict(
                 {"index": Box(shape=(1, ), low=0, high=size - 1),
                  "dict": Dict({
-                     "tuple": Tuple((Discrete(2), Box(shape=(2,), low=0, high=1, dtype=np.float64))),
-                     "rand": Box(shape=(1,2), low=0, high=1, dtype=np.float64)})
-                })
+                     "tuple": Tuple((Discrete(2), Box(shape=(2,),
+                                     low=0, high=1, dtype=np.float64))),
+                     "rand": Box(shape=(1, 2), low=0, high=1,
+                                 dtype=np.float64)})
+                 })
         else:
             self.observation_space = Box(shape=(1, ), low=0, high=size - 1)
         if multidiscrete_action:
@@ -38,6 +42,7 @@ class MyTestEnv(gym.Env):
             self.action_space = Discrete(2)
         self.done = False
         self.index = 0
+        self.seed()
 
     def seed(self, seed=0):
         self.rng = np.random.RandomState(seed)
@@ -57,10 +62,12 @@ class MyTestEnv(gym.Env):
     def _get_dict_state(self):
         """Generate a dict_state if dict_state is True."""
         if self.dict_state:
-            return {'index': np.array([self.index], dtype=np.float32), 'rand': self.rng.rand(1)}
+            return {'index': np.array([self.index], dtype=np.float32),
+                    'rand': self.rng.rand(1)}
         elif self.recurse_state:
             return {'index': np.array([self.index], dtype=np.float32),
-                    'dict': {"tuple": (np.array([1], dtype=np.int64), self.rng.rand(2)),
+                    'dict': {"tuple": (np.array([1],
+                                       dtype=np.int64), self.rng.rand(2)),
                              "rand": self.rng.rand(1, 2)}}
         else:
             return np.array([self.index], dtype=np.float32)

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -68,10 +68,9 @@ def test_stack(size=5, bufsize=9, stack_num=4):
             obs = env.reset(1)
     indice = np.arange(len(buf))
     assert np.allclose(buf.get(indice, 'obs'), np.expand_dims(
-        np.array([
-            [1, 1, 1, 2], [1, 1, 2, 3], [1, 2, 3, 4],
-            [1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 2, 3],
-            [3, 3, 3, 3], [3, 3, 3, 4], [1, 1, 1, 1]]), axis=2))
+        [[1, 1, 1, 2], [1, 1, 2, 3], [1, 2, 3, 4],
+         [1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 2, 3],
+         [3, 3, 3, 3], [3, 3, 3, 4], [1, 1, 1, 1]], axis=-1))
     print(buf)
     _, indice = buf2.sample(0)
     assert indice == [2]

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -67,10 +67,11 @@ def test_stack(size=5, bufsize=9, stack_num=4):
         if done:
             obs = env.reset(1)
     indice = np.arange(len(buf))
-    assert np.allclose(buf.get(indice, 'obs'), np.array([
-        [1, 1, 1, 2], [1, 1, 2, 3], [1, 2, 3, 4],
-        [1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 2, 3],
-        [3, 3, 3, 3], [3, 3, 3, 4], [1, 1, 1, 1]]))
+    assert np.allclose(buf.get(indice, 'obs'), np.expand_dims(
+        np.array([
+            [1, 1, 1, 2], [1, 1, 2, 3], [1, 2, 3, 4],
+            [1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 2, 3],
+            [3, 3, 3, 3], [3, 3, 3, 4], [1, 1, 1, 1]]), axis=2))
     print(buf)
     _, indice = buf2.sample(0)
     assert indice == [2]

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -72,34 +72,39 @@ def test_collector():
     c0 = Collector(policy, env, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c0.collect(n_step=3)
-    assert np.allclose(c0.buffer.obs[:4], [0, 1, 0, 1])
-    assert np.allclose(c0.buffer[:4].obs_next, [1, 2, 1, 2])
+    assert np.allclose(c0.buffer.obs[:4], [[0], [1], [0], [1]])
+    assert np.allclose(c0.buffer[:4].obs_next, [[1], [2], [1], [2]])
     c0.collect(n_episode=3)
-    assert np.allclose(c0.buffer.obs[:10], [0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
-    assert np.allclose(c0.buffer[:10].obs_next, [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
+    assert np.allclose(c0.buffer.obs[:10], [[0], [1], [0], [1], [0],
+                                            [1], [0], [1], [0], [1]])
+    assert np.allclose(c0.buffer[:10].obs_next, [[1], [2], [1], [2], [1],
+                                                 [2], [1], [2], [1], [2]])
     c0.collect(n_step=3, random=True)
     c1 = Collector(policy, venv, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c1.collect(n_step=6)
-    assert np.allclose(c1.buffer.obs[:11], [0, 1, 0, 1, 2, 0, 1, 0, 1, 2, 3])
+    assert np.allclose(c1.buffer.obs[:11], [[0], [1], [0], [1], [2], [0],
+                                            [1], [0], [1], [2], [3]])
     assert np.allclose(c1.buffer[:11].obs_next,
-                       [1, 2, 1, 2, 3, 1, 2, 1, 2, 3, 4])
+                       [[1], [2], [1], [2], [3], [1], [2], [1], [2], [3], [4]])
     c1.collect(n_episode=2)
-    assert np.allclose(c1.buffer.obs[11:21], [0, 1, 2, 3, 4, 0, 1, 0, 1, 2])
+    assert np.allclose(c1.buffer.obs[11:21], [[0], [1], [2], [3], [4],
+                                              [0], [1], [0], [1], [2]])
     assert np.allclose(c1.buffer[11:21].obs_next,
-                       [1, 2, 3, 4, 5, 1, 2, 1, 2, 3])
+                       [[1], [2], [3], [4], [5], [1], [2], [1], [2], [3]])
     c1.collect(n_episode=3, random=True)
     c2 = Collector(policy, dum, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c2.collect(n_episode=[1, 2, 2, 2])
     assert np.allclose(c2.buffer.obs_next[:26], [
-        1, 2, 1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5,
-        1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5])
+        [1], [2], [1], [2], [3], [1], [2], [3], [4], [1], [2], [3], [4], [5],
+        [1], [2], [3], [1], [2], [3], [4], [1], [2], [3], [4], [5]])
     c2.reset_env()
     c2.collect(n_episode=[2, 2, 2, 2])
     assert np.allclose(c2.buffer.obs_next[26:54], [
-        1, 2, 1, 2, 3, 1, 2, 1, 2, 3, 4, 1, 2, 3, 4, 5,
-        1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5])
+        [1], [2], [1], [2], [3], [1], [2], [1], [2], [3],
+        [4], [1], [2], [3], [4], [5], [1], [2], [3], [1],
+        [2], [3], [4], [1], [2], [3], [4], [5]])
     c2.collect(n_episode=[1, 1, 1, 1], random=True)
 
 
@@ -145,6 +150,8 @@ def test_collector_with_async():
         assert j - i == env_lens[env_id[i]]
         obs_ground_truth += list(range(j - i))
         i = j
+    obs_ground_truth = np.expand_dims(
+        np.array(obs_ground_truth), axis=1)
     assert np.allclose(obs, obs_ground_truth)
 
 
@@ -170,9 +177,12 @@ def test_collector_with_dict_state():
     print(batch)
     c0.buffer.update(c1.buffer)
     assert np.allclose(c0.buffer[:len(c0.buffer)].obs.index, [
-        0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
-        0., 1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4., 0., 1., 0.,
-        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.])
+        [0.], [1.], [2.], [3.], [4.], [0.], [1.], [2.], [3.],
+        [4.], [0.], [1.], [2.], [3.], [4.], [0.], [1.], [0.],
+        [1.], [2.], [0.], [1.], [0.], [1.], [2.], [3.], [0.],
+        [1.], [2.], [3.], [4.], [0.], [1.], [0.], [1.], [2.],
+        [0.], [1.], [0.], [1.], [2.], [3.], [0.], [1.], [2.],
+        [3.], [4.]])
     c2 = Collector(policy, envs, ReplayBuffer(size=100, stack_num=4),
                    Logger.single_preprocess_fn)
     c2.collect(n_episode=[0, 0, 0, 10])
@@ -204,10 +214,10 @@ def test_collector_with_ma():
     batch = c1.sample(10)
     print(batch)
     c0.buffer.update(c1.buffer)
-    obs = [
+    obs = np.array(np.expand_dims([
         0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
         0., 1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4., 0., 1., 0.,
-        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.]
+        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.], axis=1))
     assert np.allclose(c0.buffer[:len(c0.buffer)].obs, obs)
     rew = [0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1,
            0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -72,39 +72,40 @@ def test_collector():
     c0 = Collector(policy, env, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c0.collect(n_step=3)
-    assert np.allclose(c0.buffer.obs[:4], [[0], [1], [0], [1]])
-    assert np.allclose(c0.buffer[:4].obs_next, [[1], [2], [1], [2]])
+    assert np.allclose(c0.buffer.obs[:4], np.expand_dims(
+                                                    [0, 1, 0, 1], axis=-1))
+    assert np.allclose(c0.buffer[:4].obs_next, np.expand_dims(
+                                                [1, 2, 1, 2], axis=-1))
     c0.collect(n_episode=3)
-    assert np.allclose(c0.buffer.obs[:10], [[0], [1], [0], [1], [0],
-                                            [1], [0], [1], [0], [1]])
-    assert np.allclose(c0.buffer[:10].obs_next, [[1], [2], [1], [2], [1],
-                                                 [2], [1], [2], [1], [2]])
+    assert np.allclose(c0.buffer.obs[:10], np.expand_dims(
+                                [0, 1, 0, 1, 0, 1, 0, 1, 0, 1], axis=-1))
+    assert np.allclose(c0.buffer[:10].obs_next, np.expand_dims(
+                                    [1, 2, 1, 2, 1, 2, 1, 2, 1, 2], axis=-1))
     c0.collect(n_step=3, random=True)
     c1 = Collector(policy, venv, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c1.collect(n_step=6)
-    assert np.allclose(c1.buffer.obs[:11], [[0], [1], [0], [1], [2], [0],
-                                            [1], [0], [1], [2], [3]])
-    assert np.allclose(c1.buffer[:11].obs_next,
-                       [[1], [2], [1], [2], [3], [1], [2], [1], [2], [3], [4]])
+    assert np.allclose(c1.buffer.obs[:11], np.expand_dims(
+                            [0, 1, 0, 1, 2, 0, 1, 0, 1, 2, 3], axis=-1))
+    assert np.allclose(c1.buffer[:11].obs_next, np.expand_dims([
+                                1, 2, 1, 2, 3, 1, 2, 1, 2, 3, 4], axis=-1))
     c1.collect(n_episode=2)
-    assert np.allclose(c1.buffer.obs[11:21], [[0], [1], [2], [3], [4],
-                                              [0], [1], [0], [1], [2]])
+    assert np.allclose(c1.buffer.obs[11:21], np.expand_dims(
+                            [0, 1, 2, 3, 4, 0, 1, 0, 1, 2], axis=-1))
     assert np.allclose(c1.buffer[11:21].obs_next,
-                       [[1], [2], [3], [4], [5], [1], [2], [1], [2], [3]])
+                       np.expand_dims([1, 2, 3, 4, 5, 1, 2, 1, 2, 3], axis=-1))
     c1.collect(n_episode=3, random=True)
     c2 = Collector(policy, dum, ReplayBuffer(size=100, ignore_obs_next=False),
                    logger.preprocess_fn)
     c2.collect(n_episode=[1, 2, 2, 2])
-    assert np.allclose(c2.buffer.obs_next[:26], [
-        [1], [2], [1], [2], [3], [1], [2], [3], [4], [1], [2], [3], [4], [5],
-        [1], [2], [3], [1], [2], [3], [4], [1], [2], [3], [4], [5]])
+    assert np.allclose(c2.buffer.obs_next[:26], np.expand_dims([
+        1, 2, 1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5,
+        1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5], axis=-1))
     c2.reset_env()
     c2.collect(n_episode=[2, 2, 2, 2])
-    assert np.allclose(c2.buffer.obs_next[26:54], [
-        [1], [2], [1], [2], [3], [1], [2], [1], [2], [3],
-        [4], [1], [2], [3], [4], [5], [1], [2], [3], [1],
-        [2], [3], [4], [1], [2], [3], [4], [5]])
+    assert np.allclose(c2.buffer.obs_next[26:54], np.expand_dims([
+        1, 2, 1, 2, 3, 1, 2, 1, 2, 3, 4, 1, 2, 3, 4, 5,
+        1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5], axis=-1))
     c2.collect(n_episode=[1, 1, 1, 1], random=True)
 
 
@@ -151,7 +152,7 @@ def test_collector_with_async():
         obs_ground_truth += list(range(j - i))
         i = j
     obs_ground_truth = np.expand_dims(
-        np.array(obs_ground_truth), axis=1)
+        np.array(obs_ground_truth), axis=-1)
     assert np.allclose(obs, obs_ground_truth)
 
 
@@ -176,13 +177,10 @@ def test_collector_with_dict_state():
     batch = c1.sample(10)
     print(batch)
     c0.buffer.update(c1.buffer)
-    assert np.allclose(c0.buffer[:len(c0.buffer)].obs.index, [
-        [0.], [1.], [2.], [3.], [4.], [0.], [1.], [2.], [3.],
-        [4.], [0.], [1.], [2.], [3.], [4.], [0.], [1.], [0.],
-        [1.], [2.], [0.], [1.], [0.], [1.], [2.], [3.], [0.],
-        [1.], [2.], [3.], [4.], [0.], [1.], [0.], [1.], [2.],
-        [0.], [1.], [0.], [1.], [2.], [3.], [0.], [1.], [2.],
-        [3.], [4.]])
+    assert np.allclose(c0.buffer[:len(c0.buffer)].obs.index, np.expand_dims([
+        0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
+        0., 1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4., 0., 1., 0.,
+        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.], axis=-1))
     c2 = Collector(policy, envs, ReplayBuffer(size=100, stack_num=4),
                    Logger.single_preprocess_fn)
     c2.collect(n_episode=[0, 0, 0, 10])
@@ -217,7 +215,7 @@ def test_collector_with_ma():
     obs = np.array(np.expand_dims([
         0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
         0., 1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4., 0., 1., 0.,
-        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.], axis=1))
+        1., 2., 0., 1., 0., 1., 2., 3., 0., 1., 2., 3., 4.], axis=-1))
     assert np.allclose(c0.buffer[:len(c0.buffer)].obs, obs)
     rew = [0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1,
            0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -18,7 +18,7 @@ def recurse_comp(a, b):
                 return np.array(
                     [recurse_comp(m, n) for m, n in zip(a, b)]).all()
             else:
-                return (a == b).all()
+                return np.allclose(a, b)
         elif isinstance(a, (list, tuple)):
             return np.array(
                 [recurse_comp(m, n) for m, n in zip(a, b)]).all()

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -3,7 +3,7 @@ import numpy as np
 from gym.spaces.discrete import Discrete
 from tianshou.data import Batch
 from tianshou.env import VectorEnv, SubprocVectorEnv, \
-    RayVectorEnv, AsyncVectorEnv
+    RayVectorEnv, AsyncVectorEnv, ShmemVectorEnv
 
 if __name__ == '__main__':
     from env import MyTestEnv
@@ -62,6 +62,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
     venv = [
         VectorEnv(env_fns),
         SubprocVectorEnv(env_fns),
+        ShmemVectorEnv(env_fns)
     ]
     if verbose:
         venv.append(RayVectorEnv(env_fns))
@@ -77,9 +78,11 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 if sum(C):
                     A = v.reset(np.where(C)[0])
                 o.append([A, B, C, D])
-            for i in zip(*o):
-                for j in range(1, len(i) - 1):
-                    assert (i[0] == i[j]).all()
+            for index, infos in enumerate(zip(*o)):
+                if index == 3:
+                    continue
+                for info in infos:
+                    assert (infos[0] == info).all()
     else:
         t = [0, 0, 0]
         for i, e in enumerate(venv):

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -84,7 +84,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 for info in infos:
                     assert (infos[0] == info).all()
     else:
-        t = [0, 0, 0]
+        t = [0]*len(venv)
         for i, e in enumerate(venv):
             t[i] = time.time()
             e.reset()
@@ -93,9 +93,8 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 if sum(done) > 0:
                     e.reset(np.where(done)[0])
             t[i] = time.time() - t[i]
-        print(f'VectorEnv: {t[0]:.6f}s')
-        print(f'SubprocVectorEnv: {t[1]:.6f}s')
-        print(f'RayVectorEnv: {t[2]:.6f}s')
+        for i, v in enumerate(venv):
+            print(str(type(v))+f': {t[i]:.6f}s')
     for v in venv:
         assert v.size == list(range(size, size + num))
         assert v.env_num == num

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -55,8 +55,9 @@ def test_async_env(num=8, sleep=0.1):
 
 def test_vecenv(size=10, num=8, sleep=0.001):
     verbose = __name__ == '__main__'
+    verbose = False
     env_fns = [
-        lambda i=i: MyTestEnv(size=i, sleep=sleep)
+        lambda i=i: MyTestEnv(size=i, sleep=sleep, recurse_state=True)
         for i in range(size, size + num)
     ]
     venv = [
@@ -67,7 +68,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
     if verbose:
         venv.append(RayVectorEnv(env_fns))
     for v in venv:
-        v.seed()
+        v.seed(0)
     action_list = [1] * 5 + [0] * 10 + [1] * 20
     if not verbose:
         o = [v.reset() for v in venv]
@@ -82,6 +83,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 if index == 3:  # do not check info here
                     continue
                 for info in infos:
+                    print(index)
                     assert (infos[0] == info).all()
     else:
         t = [0] * len(venv)

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -84,7 +84,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 for info in infos:
                     assert (infos[0] == info).all()
     else:
-        t = [0]*len(venv)
+        t = [0] * len(venv)
         for i, e in enumerate(venv):
             t[i] = time.time()
             e.reset()
@@ -94,7 +94,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                     e.reset(np.where(done)[0])
             t[i] = time.time() - t[i]
         for i, v in enumerate(venv):
-            print(str(type(v))+f': {t[i]:.6f}s')
+            print(str(type(v)) + f': {t[i]:.6f}s')
     for v in venv:
         assert v.size == list(range(size, size + num))
         assert v.env_num == num

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -10,22 +10,24 @@ if __name__ == '__main__':
 else:  # pytest
     from test.base.env import MyTestEnv
 
+
 def recurse_comp(a, b):
     try:
         if isinstance(a, np.ndarray):
             if a.dtype == np.object:
                 return np.array(
-                    [recurse_comp(m, n) for m, n in zip(a, b)]).all()                
+                    [recurse_comp(m, n) for m, n in zip(a, b)]).all()
             else:
-                return (a==b).all()
+                return (a == b).all()
         elif isinstance(a, (list, tuple)):
             return np.array(
                 [recurse_comp(m, n) for m, n in zip(a, b)]).all()
         elif isinstance(a, dict):
             return np.array(
                 [recurse_comp(a[k], b[k]) for k in a.keys()]).all()
-    except:
+    except(Exception):
         return False
+
 
 def test_async_env(num=8, sleep=0.1):
     # simplify the test case, just keep stepping

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -62,7 +62,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
     venv = [
         VectorEnv(env_fns),
         SubprocVectorEnv(env_fns),
-        ShmemVectorEnv(env_fns)
+        ShmemVectorEnv(env_fns),
     ]
     if verbose:
         venv.append(RayVectorEnv(env_fns))
@@ -79,7 +79,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                     A = v.reset(np.where(C)[0])
                 o.append([A, B, C, D])
             for index, infos in enumerate(zip(*o)):
-                if index == 3:
+                if index == 3:  # do not check info here
                     continue
                 for info in infos:
                     assert (infos[0] == info).all()
@@ -94,7 +94,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                     e.reset(np.where(done)[0])
             t[i] = time.time() - t[i]
         for i, v in enumerate(venv):
-            print(str(type(v)) + f': {t[i]:.6f}s')
+            print(f'{type(v)}: {t[i]:.6f}s')
     for v in venv:
         assert v.size == list(range(size, size + num))
         assert v.env_num == num

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -10,6 +10,22 @@ if __name__ == '__main__':
 else:  # pytest
     from test.base.env import MyTestEnv
 
+def recurse_comp(a, b):
+    try:
+        if isinstance(a, np.ndarray):
+            if a.dtype == np.object:
+                return np.array(
+                    [recurse_comp(m, n) for m, n in zip(a, b)]).all()                
+            else:
+                return (a==b).all()
+        elif isinstance(a, (list, tuple)):
+            return np.array(
+                [recurse_comp(m, n) for m, n in zip(a, b)]).all()
+        elif isinstance(a, dict):
+            return np.array(
+                [recurse_comp(a[k], b[k]) for k in a.keys()]).all()
+    except:
+        return False
 
 def test_async_env(num=8, sleep=0.1):
     # simplify the test case, just keep stepping
@@ -83,8 +99,7 @@ def test_vecenv(size=10, num=8, sleep=0.001):
                 if index == 3:  # do not check info here
                     continue
                 for info in infos:
-                    print(index)
-                    assert (infos[0] == info).all()
+                    assert recurse_comp(infos[0], info)
     else:
         t = [0] * len(venv)
         for i, e in enumerate(venv):

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -73,7 +73,6 @@ def test_async_env(num=8, sleep=0.1):
 
 def test_vecenv(size=10, num=8, sleep=0.001):
     verbose = __name__ == '__main__'
-    verbose = False
     env_fns = [
         lambda i=i: MyTestEnv(size=i, sleep=sleep, recurse_state=True)
         for i in range(size, size + num)

--- a/tianshou/env/__init__.py
+++ b/tianshou/env/__init__.py
@@ -3,6 +3,7 @@ from tianshou.env.vecenv.dummy import VectorEnv
 from tianshou.env.vecenv.subproc import SubprocVectorEnv
 from tianshou.env.vecenv.asyncenv import AsyncVectorEnv
 from tianshou.env.vecenv.rayenv import RayVectorEnv
+from tianshou.env.vecenv.shmemenv import ShmemVectorEnv
 from tianshou.env.maenv import MultiAgentEnv
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     'SubprocVectorEnv',
     'AsyncVectorEnv',
     'RayVectorEnv',
-    'MultiAgentEnv',
+    'ShmemVectorEnv',
+    'MultiAgentEnv'
 ]

--- a/tianshou/env/__init__.py
+++ b/tianshou/env/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     'AsyncVectorEnv',
     'RayVectorEnv',
     'ShmemVectorEnv',
-    'MultiAgentEnv'
+    'MultiAgentEnv',
 ]

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -17,7 +17,7 @@ _NP_TO_CT = {np.float64: ctypes.c_double,
              np.bool: ctypes.c_bool}
 
 
-def shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
+def _shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
                  obs_shapes, obs_dtypes, keys):
     """Control a single environment instance using IPC and
     shared memory.
@@ -85,7 +85,7 @@ class ShmemVectorEnv(SubprocVectorEnv):
         self.parent_remote, self.child_remote = \
             zip(*[Pipe() for _ in range(self.env_num)])
         self.processes = [
-            Process(target=shmem_worker, args=(
+            Process(target=_shmem_worker, args=(
                 parent, child, CloudpickleWrapper(env_fn),
                 obs_buf, self.obs_shapes,
                 self.obs_dtypes, self.obs_keys), daemon=True)

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -60,20 +60,25 @@ def _shmem_worker(parent, p, env_fn_wrapper, obs_bufs):
     except KeyboardInterrupt:
         p.close()
 
+
 class ShArray:
     """Wrapper of multiprocessing Array"""
+
     def __init__(self, dtype, shape):
         self.arr = Array(_NP_TO_CT[dtype.type], int(np.prod(shape)))
         self.dtype = dtype
         self.shape = shape
+
     def save(self, ndarray):
         assert isinstance(ndarray, np.ndarray)
         dst = self.arr.get_obj()
-        dst_np = np.frombuffer(dst, dtype = self.dtype).reshape(self.shape)
+        dst_np = np.frombuffer(dst, dtype=self.dtype).reshape(self.shape)
         np.copyto(dst_np, ndarray)
+
     def get(self):
         return np.frombuffer(self.arr.get_obj(),
                              dtype=self.dtype).reshape(self.shape)
+
 
 class ShmemVectorEnv(SubprocVectorEnv):
     """Optimized version of SubprocVectorEnv that uses shared variables to
@@ -91,14 +96,15 @@ class ShmemVectorEnv(SubprocVectorEnv):
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:
         BaseVectorEnv.__init__(self, env_fns)
-        #Mind that SubprocVectorEnv is not initialised.
+        # Mind that SubprocVectorEnv is not initialised.
         self.closed = False
         dummy = env_fns[0]()
         obs_space = dummy.observation_space
         dummy.close()
         del dummy
-        #will copy be quicker?
-        self.obs_bufs = [self._setup_buf(obs_space) for _ in range(self.env_num)]
+        # will copy be quicker?
+        self.obs_bufs = [self._setup_buf(obs_space)
+                         for _ in range(self.env_num)]
         self.parent_remote, self.child_remote = \
             zip(*[Pipe() for _ in range(self.env_num)])
         self.processes = [
@@ -166,9 +172,3 @@ class ShmemVectorEnv(SubprocVectorEnv):
                 raise NotImplementedError
         assert isNone is None
         return decode_obs(self.obs_bufs[index])
-
-        
-        
-
-
-

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -82,14 +82,15 @@ class ShArray:
 
 class ShmemVectorEnv(SubprocVectorEnv):
     """Optimized version of SubprocVectorEnv that uses shared variables to
-    communicate observations.
+    communicate observations. SubprocVectorEnv has exactly the same API as 
+    SubprocVectorEnv.
 
     .. seealso::
 
-        Please refer to :class:`~tianshou.env.BaseVectorEnv` for more detailed
+        Please refer to :class:`~tianshou.env.SubprocVectorEnv` for more detailed
         explanation.
 
-    I was inspired by openai baseline to implement ShmemVectorEnv Class.
+    ShmemVectorEnv Class was inspired by openai baseline's implementation.
     Please refer to 'https://github.com/openai/baselines/blob/master/baselines/
     common/vec_env/shmem_vec_env.py' for more info if you are interested.
     """

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -18,7 +18,7 @@ _NP_TO_CT = {np.float64: ctypes.c_double,
 
 
 def _shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
-                 obs_shapes, obs_dtypes, keys):
+                  obs_shapes, obs_dtypes, keys):
     """Control a single environment instance using IPC and
     shared memory.
     """

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -75,6 +75,7 @@ class ShmemVectorEnv(SubprocVectorEnv):
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:
         BaseVectorEnv.__init__(self, env_fns)
+        self.closed = False
         self._setup_obs_space(env_fns[0])
         self.obs_bufs = [
             {k: Array(_NP_TO_CT[self.obs_dtypes[k].type], int(

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -67,11 +67,11 @@ class ShmemVectorEnv(SubprocVectorEnv):
 
         Please refer to :class:`~tianshou.env.BaseVectorEnv` for more detailed
         explanation.
-    """
-    """I borrowed heavily from openai baseline to implement ShmemVectorEnv Class.
+
+    I borrowed heavily from openai baseline to implement ShmemVectorEnv Class.
     Please refer to 'https://github.com/openai/baselines/blob/master/baselines/
     common/vec_env/shmem_vec_env.py' for more info if you are interested.
-                                Huayu Chen(chenhuay17@mails.tsinghua.edu.cn)
+                    Huayu Chen(chenhuay17@mails.tsinghua.edu.cn)  2020/08/01
     """
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -174,5 +174,4 @@ class ShmemVectorEnv(SubprocVectorEnv):
                 return {k: decode_obs(v) for k, v in buffer.items()}
             else:
                 raise NotImplementedError
-        assert isNone is None
         return decode_obs(self.obs_bufs[index])

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -68,10 +68,9 @@ class ShmemVectorEnv(SubprocVectorEnv):
         Please refer to :class:`~tianshou.env.BaseVectorEnv` for more detailed
         explanation.
 
-    I borrowed heavily from openai baseline to implement ShmemVectorEnv Class.
+    I borrow heavily from openai baseline to implement ShmemVectorEnv Class.
     Please refer to 'https://github.com/openai/baselines/blob/master/baselines/
     common/vec_env/shmem_vec_env.py' for more info if you are interested.
-                    Huayu Chen(chenhuay17@mails.tsinghua.edu.cn)  2020/08/01
     """
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -82,13 +82,13 @@ class ShArray:
 
 class ShmemVectorEnv(SubprocVectorEnv):
     """Optimized version of SubprocVectorEnv that uses shared variables to
-    communicate observations. SubprocVectorEnv has exactly the same API as 
+    communicate observations. SubprocVectorEnv has exactly the same API as
     SubprocVectorEnv.
 
     .. seealso::
 
-        Please refer to :class:`~tianshou.env.SubprocVectorEnv` for more detailed
-        explanation.
+        Please refer to :class:`~tianshou.env.SubprocVectorEnv` for more
+        detailed explanation.
 
     ShmemVectorEnv Class was inspired by openai baseline's implementation.
     Please refer to 'https://github.com/openai/baselines/blob/master/baselines/

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -1,0 +1,160 @@
+import ctypes
+from collections import OrderedDict
+from multiprocessing import Pipe, Process, Array
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+import gym
+import numpy as np
+
+from tianshou.env import BaseVectorEnv, SubprocVectorEnv
+from tianshou.env.utils import CloudpickleWrapper
+
+_NP_TO_CT = {np.float64: ctypes.c_double,
+             np.float32: ctypes.c_float,
+             np.int32: ctypes.c_int32,
+             np.int8: ctypes.c_int8,
+             np.uint8: ctypes.c_char,
+             np.bool: ctypes.c_bool}
+
+
+def shmem_worker(parent, p, env_fn_wrapper, obs_bufs, obs_shapes, obs_dtypes, keys):
+    """
+    Control a single environment instance using IPC and
+    shared memory.
+    """
+    def _encode_obs(maybe_dict):
+        flatdict = maybe_dict if isinstance(maybe_dict, dict) else {
+            None: maybe_dict}
+        for k in keys:
+            dst = obs_bufs[k].get_obj()
+            dst_np = np.frombuffer(dst, dtype=obs_dtypes[k]).reshape(
+                obs_shapes[k])  # pylint: disable=W0212
+            np.copyto(dst_np, flatdict[k])
+        # return None
+
+    parent.close()
+    env = env_fn_wrapper.data()
+    try:
+        while True:
+            cmd, data = p.recv()
+            if cmd == 'step':
+                obs, reward, done, info = env.step(data)
+                p.send((_encode_obs(obs), reward, done, info))
+            elif cmd == 'reset':
+                p.send(_encode_obs(env.reset()))
+            elif cmd == 'close':
+                p.send(env.close())
+                p.close()
+                break
+            elif cmd == 'render':
+                p.send(env.render(**data) if hasattr(env, 'render') else None)
+            elif cmd == 'seed':
+                p.send(env.seed(data) if hasattr(env, 'seed') else None)
+            elif cmd == 'getattr':
+                p.send(getattr(env, data) if hasattr(env, data) else None)
+            else:
+                p.close()
+                raise NotImplementedError
+    except KeyboardInterrupt:
+        p.close()
+
+# init set up
+
+
+class ShmemVectorEnv(SubprocVectorEnv):
+    """Optimized version of SubprocVectorEnv that uses shared 
+    variables to communicate observations.
+
+    .. seealso::
+
+        Please refer to :class:`~tianshou.env.BaseVectorEnv` for more detailed
+        explanation.
+    """
+
+    def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:
+        BaseVectorEnv.__init__(self, env_fns)  # to be checked
+        self.closed = False
+        self._setup_obs_space(env_fns[0])
+        # t b c
+        self.obs_bufs = [
+            {k: Array(_NP_TO_CT[self.obs_dtypes[k].type], int(
+                np.prod(self.obs_shapes[k]))) for k in self.obs_keys}
+            for _ in range(self.env_num)]
+        self.parent_remote, self.child_remote = \
+            zip(*[Pipe() for _ in range(self.env_num)])
+        self.processes = [
+            Process(target=shmem_worker, args=(
+                parent, child, CloudpickleWrapper(env_fn),
+                obs_buf, self.obs_shapes,
+                self.obs_dtypes, self.obs_keys), daemon=True)
+            for (parent, child, env_fn, obs_buf) in zip(
+                self.parent_remote, self.child_remote, env_fns, self.obs_bufs)
+        ]
+        for p in self.processes:
+            p.start()
+        for c in self.child_remote:
+            c.close()
+
+    def step(self,
+             action: np.ndarray,
+             id: Optional[Union[int, List[int]]] = None
+             ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if id is None:
+            id = range(self.env_num)
+        elif np.isscalar(id):
+            id = [id]
+        assert len(action) == len(id)
+        for i, j in enumerate(id):
+            self.parent_remote[j].send(['step', action[i]])
+        result = []
+        for i in id:
+            obs, rew, done, info = self.parent_remote[i].recv()
+            obs = self._decode_obs(obs, i)
+            result.append((obs, rew, done, info))
+        # t b c dict
+        obs, rew, done, info = map(np.stack, zip(*result))
+        return obs, rew, done, info
+
+    def reset(self, id: Optional[Union[int, List[int]]] = None) -> np.ndarray:
+        if id is None:
+            id = range(self.env_num)
+        elif np.isscalar(id):
+            id = [id]
+        for i in id:
+            self.parent_remote[i].send(['reset', None])
+        obs = np.stack(
+            [self._decode_obs(self.parent_remote[i].recv(), i) for i in id])
+        return obs
+
+    def _setup_obs_space(self, env):
+        """Get dict-structured information about a gym.Space."""
+        dummy = env()
+        obs_space = dummy.observation_space
+        dummy.close()
+        del dummy
+        if isinstance(obs_space, gym.spaces.Dict):
+            assert isinstance(obs_space.spaces, OrderedDict)
+            subspaces = obs_space.spaces
+        elif isinstance(obs_space, gym.spaces.Tuple):
+            assert isinstance(obs_space.spaces, tuple)
+            subspaces = {i: obs_space.spaces[i]
+                         for i in range(len(obs_space.spaces))}
+        else:
+            subspaces = {None: obs_space}
+        self.obs_keys = []
+        self.obs_shapes = {}
+        self.obs_dtypes = {}
+        for key, box in subspaces.items():
+            self.obs_keys.append(key)
+            self.obs_shapes[key] = box.shape
+            self.obs_dtypes[key] = box.dtype
+
+    def _decode_obs(self, isNone, index):
+        # suppose there is simply no dict of obs
+        assert isNone is None
+        result = {}
+        for k in self.obs_keys:
+            result[k] = np.frombuffer(
+                self.obs_bufs[index][k].get_obj(),
+                dtype=self.obs_dtypes[k]).reshape(self.obs_shapes[k])
+        return result if not result.keys() == {None} else result[None]

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -19,8 +19,7 @@ _NP_TO_CT = {np.float64: ctypes.c_double,
 
 def shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
                  obs_shapes, obs_dtypes, keys):
-    """
-    Control a single environment instance using IPC and
+    """Control a single environment instance using IPC and
     shared memory.
     """
     def _encode_obs(maybe_dict):
@@ -29,9 +28,9 @@ def shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
         for k in keys:
             dst = obs_bufs[k].get_obj()
             dst_np = np.frombuffer(dst, dtype=obs_dtypes[k]).reshape(
-                obs_shapes[k])  # pylint: disable=W0212
+                obs_shapes[k])
             np.copyto(dst_np, flatdict[k])
-        # return None
+        return None
 
     parent.close()
     env = env_fn_wrapper.data()
@@ -69,12 +68,16 @@ class ShmemVectorEnv(SubprocVectorEnv):
         Please refer to :class:`~tianshou.env.BaseVectorEnv` for more detailed
         explanation.
     """
+    """I borrowed heavily from openai baseline to implement ShmemVectorEnv Class.
+    Please refer to 'https://github.com/openai/baselines/blob/master/baselines/
+    common/vec_env/shmem_vec_env.py' for more info if you are interested.
+                                Huayu Chen(chenhuay17@mails.tsinghua.edu.cn)
+    """
 
     def __init__(self, env_fns: List[Callable[[], gym.Env]]) -> None:
-        BaseVectorEnv.__init__(self, env_fns)  # to be checked
+        BaseVectorEnv.__init__(self, env_fns)
         self.closed = False
         self._setup_obs_space(env_fns[0])
-        # t b c
         self.obs_bufs = [
             {k: Array(_NP_TO_CT[self.obs_dtypes[k].type], int(
                 np.prod(self.obs_shapes[k]))) for k in self.obs_keys}
@@ -110,7 +113,6 @@ class ShmemVectorEnv(SubprocVectorEnv):
             obs, rew, done, info = self.parent_remote[i].recv()
             obs = self._decode_obs(obs, i)
             result.append((obs, rew, done, info))
-        # t b c dict
         obs, rew, done, info = map(np.stack, zip(*result))
         return obs, rew, done, info
 
@@ -126,7 +128,6 @@ class ShmemVectorEnv(SubprocVectorEnv):
         return obs
 
     def _setup_obs_space(self, env):
-        """Get dict-structured information about a gym.Space."""
         dummy = env()
         obs_space = dummy.observation_space
         dummy.close()
@@ -149,7 +150,6 @@ class ShmemVectorEnv(SubprocVectorEnv):
             self.obs_dtypes[key] = box.dtype
 
     def _decode_obs(self, isNone, index):
-        # suppose there is simply no dict of obs
         assert isNone is None
         result = {}
         for k in self.obs_keys:

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -1,7 +1,7 @@
 import ctypes
 from collections import OrderedDict
 from multiprocessing import Pipe, Process, Array
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
@@ -17,7 +17,8 @@ _NP_TO_CT = {np.float64: ctypes.c_double,
              np.bool: ctypes.c_bool}
 
 
-def shmem_worker(parent, p, env_fn_wrapper, obs_bufs, obs_shapes, obs_dtypes, keys):
+def shmem_worker(parent, p, env_fn_wrapper, obs_bufs,
+                 obs_shapes, obs_dtypes, keys):
     """
     Control a single environment instance using IPC and
     shared memory.
@@ -58,11 +59,9 @@ def shmem_worker(parent, p, env_fn_wrapper, obs_bufs, obs_shapes, obs_dtypes, ke
     except KeyboardInterrupt:
         p.close()
 
-# init set up
-
 
 class ShmemVectorEnv(SubprocVectorEnv):
-    """Optimized version of SubprocVectorEnv that uses shared 
+    """Optimized version of SubprocVectorEnv that uses shared
     variables to communicate observations.
 
     .. seealso::

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -9,17 +9,17 @@ from typing import Callable, List, Optional, Tuple, Union
 from tianshou.env import BaseVectorEnv, SubprocVectorEnv
 from tianshou.env.utils import CloudpickleWrapper
 
-_NP_TO_CT = {np.float64: ctypes.c_double,
-             np.float32: ctypes.c_float,
-             np.int64: ctypes.c_int64,
-             np.int32: ctypes.c_int32,
-             np.int16: ctypes.c_int16,
-             np.int8: ctypes.c_int8,
-             np.uint8: ctypes.c_char,
+_NP_TO_CT = {np.bool: ctypes.c_bool,
+             np.uint8: ctypes.c_uint8,
              np.uint16: ctypes.c_uint16,
              np.uint32: ctypes.c_uint32,
              np.uint64: ctypes.c_uint64,
-             np.bool: ctypes.c_bool}
+             np.int8: ctypes.c_int8,
+             np.int16: ctypes.c_int16,
+             np.int32: ctypes.c_int32,
+             np.int64: ctypes.c_int64,
+             np.float32: ctypes.c_float,
+             np.float64: ctypes.c_double}
 
 
 def _shmem_worker(parent, p, env_fn_wrapper, obs_bufs):

--- a/tianshou/env/vecenv/subproc.py
+++ b/tianshou/env/vecenv/subproc.py
@@ -7,7 +7,7 @@ from tianshou.env import BaseVectorEnv
 from tianshou.env.utils import CloudpickleWrapper
 
 
-def worker(parent, p, env_fn_wrapper):
+def _worker(parent, p, env_fn_wrapper):
     parent.close()
     env = env_fn_wrapper.data()
     try:
@@ -49,7 +49,7 @@ class SubprocVectorEnv(BaseVectorEnv):
         self.parent_remote, self.child_remote = \
             zip(*[Pipe() for _ in range(self.env_num)])
         self.processes = [
-            Process(target=worker, args=(
+            Process(target=_worker, args=(
                 parent, child, CloudpickleWrapper(env_fn)), daemon=True)
             for (parent, child, env_fn) in zip(
                 self.parent_remote, self.child_remote, env_fns)


### PR DESCRIPTION
Following OpenAI baseline, I implement ShmemVectorEnv which is an optimized version of SubprocVectorEnv that uses shared variables to communicate observations. ShmemVectorEnv has exactly the same API as SubprocVectorEnv, but when `obs.shape` is too large, the usage of shared variables can save us a lot of time.

This pr include:

* Basic Implementation of ShmemVectorEnv
* update in test_env.py to test ShmemVectorEnv
* some improvement in of test_env.py for generalization
* some fix in test/base/env.py and test_env.py

I borrow from openai baseline to implement ShmemVectorEnv Class. Please refer to https://github.com/openai/baselines/blob/master/baselines/common/vec_env/shmem_vec_env.py