### PR TITLE
fix #166, assure close in vec env

### DIFF
--- a/tianshou/env/vecenv/asyncenv.py
+++ b/tianshou/env/vecenv/asyncenv.py
@@ -52,10 +52,12 @@ class AsyncVectorEnv(SubprocVectorEnv):
         return id
 
     def reset(self, id: Optional[Union[int, List[int]]] = None) -> np.ndarray:
+        self._assert_is_closed()
         id = self._assert_and_transform_id(id)
         return super().reset(id)
 
     def render(self, **kwargs) -> List[Any]:
+        self._assert_is_closed()
         if len(self.waiting_id) > 0:
             raise RuntimeError(
                 f"Environments {self.waiting_id} are still "
@@ -80,6 +82,7 @@ class AsyncVectorEnv(SubprocVectorEnv):
         (initially they are env_ids of all the environments). If action is
         ``None``, fetch unfinished step() calls instead.
         """
+        self._assert_is_closed()
         if action is not None:
             id = self._assert_and_transform_id(id)
             assert len(action) == len(id)

--- a/tianshou/env/vecenv/base.py
+++ b/tianshou/env/vecenv/base.py
@@ -48,6 +48,10 @@ class BaseVectorEnv(ABC, gym.Env):
         """Return len(self), which is the number of environments."""
         return self.env_num
 
+    def __del__(self):
+        """Close the environment before garbage collected"""
+        self.close()
+
     def __getattribute__(self, key: str):
         """Switch between the default attribute getter or one
            looking at wrapped environment level depending on the key."""

--- a/tianshou/env/vecenv/shmemenv.py
+++ b/tianshou/env/vecenv/shmemenv.py
@@ -124,6 +124,7 @@ class ShmemVectorEnv(SubprocVectorEnv):
              action: np.ndarray,
              id: Optional[Union[int, List[int]]] = None
              ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        self._assert_is_closed()
         if id is None:
             id = range(self.env_num)
         elif np.isscalar(id):
@@ -140,6 +141,7 @@ class ShmemVectorEnv(SubprocVectorEnv):
         return obs, rew, done, info
 
     def reset(self, id: Optional[Union[int, List[int]]] = None) -> np.ndarray:
+        self._assert_is_closed()
         if id is None:
             id = range(self.env_num)
         elif np.isscalar(id):

--- a/tianshou/env/vecenv/subproc.py
+++ b/tianshou/env/vecenv/subproc.py
@@ -122,4 +122,4 @@ class SubprocVectorEnv(BaseVectorEnv):
 
     def _assert_is_closed(self):
         assert not self.closed, \
-             f"Methods of {type(self)} should not be called after closed."
+             f"Methods of {self.__class__.__name__} should not be called after closed."


### PR DESCRIPTION
fix #166 , SubprocVectorEnv and its subclasses cannot be called once closed.