### PR TITLE
unexpected keyword argument 'task'

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ result = ts.trainer.offpolicy_trainer(
     train_fn=lambda epoch, env_step: policy.set_eps(eps_train),
     test_fn=lambda epoch, env_step: policy.set_eps(eps_test),
     stop_fn=lambda mean_rewards: mean_rewards >= env.spec.reward_threshold,
-    writer=writer, task=task)
+    writer=writer)
 print(f'Finished training! Use {result["duration"]}')
 ```
 


### PR DESCRIPTION
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-7-77c1fbe7e903> in <module>()
      5     test_fn=lambda epoch, env_step: policy.set_eps(eps_test),
      6     stop_fn=lambda mean_rewards: mean_rewards >= env.spec.reward_threshold,
----> 7     writer=writer, task=task)
      8 print(f'Finished training! Use {result["duration"]}')

TypeError: offpolicy_trainer() got an unexpected keyword argument 'task'

---

https://github.com/StevenJokess/RL-Adventure/blob/master/test_dqn.ipynb

- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website](https://github.com/thu-ml/tianshou)
- [ ] I have searched through the [issue tracker](https://github.com/thu-ml/tianshou/issues) for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, torch, sys
  print(tianshou.__version__, torch.__version__, sys.version, sys.platform)
  ```
