### PR TITLE
fix 2 bugs of batch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "gym>=0.15.4",
         "tqdm",
-        "numpy!=1.16.0",  # https://github.com/numpy/numpy/issues/12793
+        "numpy!=1.16.0,<1.20.0",  # https://github.com/numpy/numpy/issues/12793
         "tensorboard",
         "torch>=1.4.0",
         "numba>=0.51.0",

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -338,8 +338,10 @@ def test_batch_cat_and_stack():
     assert np.allclose(test.common.c, ans.common.c)
 
     # test with illegal input format
-    assert Batch.cat([[Batch(a=1)], [Batch(a=1)]]).is_empty()
-    assert Batch.stack([[Batch(a=1)], [Batch(a=1)]]).is_empty()
+    with pytest.raises(ValueError):
+        Batch.cat([[Batch(a=1)], [Batch(a=1)]])
+    with pytest.raises(ValueError):
+        Batch.stack([[Batch(a=1)], [Batch(a=1)]])
 
     # exceptions
     assert Batch.cat([]).is_empty()

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -19,6 +19,8 @@ def test_batch():
     assert not Batch(a=np.float64(1.0)).is_empty()
     assert len(Batch(a=[1, 2, 3], b={'c': {}})) == 3
     assert not Batch(a=[1, 2, 3]).is_empty()
+    b = Batch({'a': [4, 4], 'b': [5, 5]}, c=[None, None])
+    assert b.c.dtype == np.object
     b = Batch()
     b.update()
     assert b.is_empty()

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -337,6 +337,10 @@ def test_batch_cat_and_stack():
     assert torch.allclose(test.b, ans.b)
     assert np.allclose(test.common.c, ans.common.c)
 
+    # test with illegal input format
+    assert Batch.cat([[Batch(a=1)], [Batch(a=1)]]).is_empty()
+    assert Batch.stack([[Batch(a=1)], [Batch(a=1)]]).is_empty()
+
     # exceptions
     assert Batch.cat([]).is_empty()
     assert Batch.stack([]).is_empty()

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -143,8 +143,10 @@ def test_batch():
     assert batch3.a.d.e[0] == 4.0
     batch3.a.d[0] = Batch(f=5.0)
     assert batch3.a.d.f[0] == 5.0
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         batch3.a.d[0] = Batch(f=5.0, g=0.0)
+    with pytest.raises(ValueError):
+        batch3[0] = Batch(a={"c": 2, "e": 1})
     # auto convert
     batch4 = Batch(a=np.array(['a', 'b']))
     assert batch4.a.dtype == np.object  # auto convert to np.object

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -621,9 +621,9 @@ def test_multibuf_hdf5():
             'done': i % 3 == 2,
             'info': {"number": {"n": i, "t": info_t}, 'extra': None},
         }
-        buffers["vector"].add(**Batch.cat([[kwargs], [kwargs], [kwargs]]),
+        buffers["vector"].add(**Batch.stack([kwargs, kwargs, kwargs]),
                               buffer_ids=[0, 1, 2])
-        buffers["cached"].add(**Batch.cat([[kwargs], [kwargs], [kwargs]]),
+        buffers["cached"].add(**Batch.stack([kwargs, kwargs, kwargs]),
                               cached_buffer_ids=[0, 1, 2])
 
     # save
@@ -657,7 +657,7 @@ def test_multibuf_hdf5():
             'done': False,
             'info': {"number": {"n": i}, 'Timelimit.truncate': True},
         }
-        buffers[k].add(**Batch.cat([[kwargs], [kwargs], [kwargs], [kwargs]]))
+        buffers[k].add(**Batch.stack([kwargs, kwargs, kwargs, kwargs]))
         act = np.zeros(buffers[k].maxsize)
         if k == "vector":
             act[np.arange(5)] = np.array([0, 1, 2, 3, 5])

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -246,8 +246,9 @@ class Batch:
         value: Any,
     ) -> None:
         """Assign value to self[index]."""
+        value = _parse_value(value)
         if isinstance(index, str):
-            self.__dict__[index] = _parse_value(value)
+            self.__dict__[index] = value
             return
         if not isinstance(value, (dict, Batch)):
             raise ValueError("Batch does not supported tensor assignment. "

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -177,18 +177,17 @@ class Batch:
         copy: bool = False,
         **kwargs: Any,
     ) -> None:
-        if batch_dict is None:
-            if len(kwargs) == 0:
-                return
-            batch_dict = kwargs
         if copy:
             batch_dict = deepcopy(batch_dict)
-        if isinstance(batch_dict, (dict, Batch)):
-            _assert_type_keys(batch_dict.keys())
-            for k, v in batch_dict.items():
-                self.__dict__[k] = _parse_value(v)
-        elif _is_batch_set(batch_dict):
-            self.stack_(batch_dict)
+        if batch_dict is not None:
+            if isinstance(batch_dict, (dict, Batch)):
+                _assert_type_keys(batch_dict.keys())
+                for k, v in batch_dict.items():
+                    self.__dict__[k] = _parse_value(v)
+            elif _is_batch_set(batch_dict):
+                self.stack_(batch_dict)
+        if len(kwargs) > 0:
+            self.__init__(kwargs, copy=copy)  # type: ignore
 
     def __setattr__(self, key: str, value: Any) -> None:
         """Set self.key = value."""

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -8,12 +8,6 @@ from collections.abc import Collection
 from typing import Any, List, Dict, Union, Iterator, Optional, Iterable, \
     Sequence
 
-# Disable pickle warning related to torch, since it has been removed
-# on torch master branch. See Pull Request #39003 for details:
-# https://github.com/pytorch/pytorch/pull/39003
-warnings.filterwarnings(
-    "ignore", message="pickle support for Storage will be removed in 1.5.")
-
 
 def _is_batch_set(data: Any) -> bool:
     # Batch set is a list/tuple of dict/Batch objects,
@@ -91,6 +85,8 @@ def _create_value(
     has_shape = isinstance(inst, (np.ndarray, torch.Tensor))
     is_scalar = _is_scalar(inst)
     if not stack and is_scalar:
+        if isinstance(inst, Batch) and inst.is_empty(recurse=True):
+            return inst
         # should never hit since it has already checked in Batch.cat_
         # here we do not consider scalar types, following the behavior of numpy
         # which does not support concatenation of zero-dimensional arrays
@@ -181,17 +177,18 @@ class Batch:
         copy: bool = False,
         **kwargs: Any,
     ) -> None:
+        if batch_dict is None:
+            if len(kwargs) == 0:
+                return
+            batch_dict = kwargs
         if copy:
             batch_dict = deepcopy(batch_dict)
-        if batch_dict is not None:
-            if isinstance(batch_dict, (dict, Batch)):
-                _assert_type_keys(batch_dict.keys())
-                for k, v in batch_dict.items():
-                    self.__dict__[k] = _parse_value(v)
-            elif _is_batch_set(batch_dict):
-                self.stack_(batch_dict)
-        if len(kwargs) > 0:
-            self.__init__(kwargs, copy=copy)  # type: ignore
+        if isinstance(batch_dict, (dict, Batch)):
+            _assert_type_keys(batch_dict.keys())
+            for k, v in batch_dict.items():
+                self.__dict__[k] = _parse_value(v)
+        elif _is_batch_set(batch_dict):
+            self.stack_(batch_dict)
 
     def __setattr__(self, key: str, value: Any) -> None:
         """Set self.key = value."""
@@ -249,15 +246,14 @@ class Batch:
         value: Any,
     ) -> None:
         """Assign value to self[index]."""
-        value = _parse_value(value)
         if isinstance(index, str):
-            self.__dict__[index] = value
+            self.__dict__[index] = _parse_value(value)
             return
-        if not isinstance(value, Batch):
+        if not isinstance(value, (dict, Batch)):
             raise ValueError("Batch does not supported tensor assignment. "
                              "Use a compatible Batch or dict instead.")
         if not set(value.keys()).issubset(self.__dict__.keys()):
-            raise KeyError(
+            raise ValueError(
                 "Creating keys is not supported by item assignment.")
         for key, val in self.items():
             try:
@@ -496,6 +492,8 @@ class Batch:
         self, batches: Sequence[Union[dict, "Batch"]], axis: int = 0
     ) -> None:
         """Stack a list of Batch object into current batch."""
+        batches = [x for x in batches if isinstance(
+            x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
         if len(batches) == 0:
             return
         batches = [x if isinstance(x, Batch) else Batch(x) for x in batches]

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -446,15 +446,21 @@ class Batch:
         """Concatenate a list of (or one) Batch objects into current batch."""
         if isinstance(batches, Batch):
             batches = [batches]
-        # filter out illegal input format, i.e., [[Batch(...)], [Batch(...)]]
-        batches = [x for x in batches if isinstance(
-            x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
-        if len(batches) == 0:
+        # check input format
+        batch_list = []
+        for b in batches:
+            if isinstance(b, dict):
+                if len(b) > 0:
+                    batch_list.append(Batch(b))
+            elif isinstance(b, Batch):
+                # x.is_empty() means that x is Batch() and should be ignored
+                if not b.is_empty():
+                    batch_list.append(b)
+            else:
+                raise ValueError(f"Cannot concatenate {type(b)} in Batch.cat_")
+        if len(batch_list) == 0:
             return
-        batches = [x if isinstance(x, Batch) else Batch(x) for x in batches]
-
-        # x.is_empty() means that x is Batch() and should be ignored
-        batches = [x for x in batches if not x.is_empty()]
+        batches = batch_list
         try:
             # x.is_empty(recurse=True) here means x is a nested empty batch
             # like Batch(a=Batch), and we have to treat it as length zero and
@@ -496,12 +502,22 @@ class Batch:
         self, batches: Sequence[Union[dict, "Batch"]], axis: int = 0
     ) -> None:
         """Stack a list of Batch object into current batch."""
-        # filter out illegal input format, i.e., [[Batch(...)], [Batch(...)]]
-        batches = [x for x in batches if isinstance(
-            x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
-        if len(batches) == 0:
+        # check input format
+        batch_list = []
+        for b in batches:
+            if isinstance(b, dict):
+                if len(b) > 0:
+                    batch_list.append(Batch(b))
+            elif isinstance(b, Batch):
+                # x.is_empty() means that x is Batch() and should be ignored
+                if not b.is_empty():
+                    batch_list.append(b)
+            else:
+                raise ValueError(
+                    f"Cannot concatenate {type(b)} in Batch.stack_")
+        if len(batch_list) == 0:
             return
-        batches = [x if isinstance(x, Batch) else Batch(x) for x in batches]
+        batches = batch_list
         if not self.is_empty():
             batches = [self] + batches
         # collect non-empty keys

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -85,6 +85,7 @@ def _create_value(
     has_shape = isinstance(inst, (np.ndarray, torch.Tensor))
     is_scalar = _is_scalar(inst)
     if not stack and is_scalar:
+        # _create_value(Batch(a={}, b=[1, 2, 3]), 10, False) will fail here
         if isinstance(inst, Batch) and inst.is_empty(recurse=True):
             return inst
         # should never hit since it has already checked in Batch.cat_
@@ -445,6 +446,7 @@ class Batch:
         """Concatenate a list of (or one) Batch objects into current batch."""
         if isinstance(batches, Batch):
             batches = [batches]
+        # filter out illegal input format, i.e., [[Batch(...)], [Batch(...)]]
         batches = [x for x in batches if isinstance(
             x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
         if len(batches) == 0:
@@ -494,6 +496,7 @@ class Batch:
         self, batches: Sequence[Union[dict, "Batch"]], axis: int = 0
     ) -> None:
         """Stack a list of Batch object into current batch."""
+        # filter out illegal input format, i.e., [[Batch(...)], [Batch(...)]]
         batches = [x for x in batches if isinstance(
             x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
         if len(batches) == 0:

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -250,7 +250,7 @@ class Batch:
         if isinstance(index, str):
             self.__dict__[index] = value
             return
-        if not isinstance(value, (dict, Batch)):
+        if not isinstance(value, Batch):
             raise ValueError("Batch does not supported tensor assignment. "
                              "Use a compatible Batch or dict instead.")
         if not set(value.keys()).issubset(self.__dict__.keys()):

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -445,6 +445,8 @@ class Batch:
         """Concatenate a list of (or one) Batch objects into current batch."""
         if isinstance(batches, Batch):
             batches = [batches]
+        batches = [x for x in batches if isinstance(
+            x, dict) and x or isinstance(x, Batch) and not x.is_empty()]
         if len(batches) == 0:
             return
         batches = [x if isinstance(x, Batch) else Batch(x) for x in batches]

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -174,7 +174,7 @@ class ReplayBuffer:
                 )
         try:
             value[self._index] = inst
-        except KeyError:  # inst is a dict/Batch
+        except ValueError:  # inst is a dict/Batch
             for key in set(inst.keys()).difference(value.keys()):
                 self._buffer_allocator([name, key], inst[key])
             self._meta[name][self._index] = inst


### PR DESCRIPTION
1. `_create_value(Batch(a={}, b=[1, 2, 3]), 10, False)`

before:
```python
TypeError: cannot concatenate with Batch() which is scalar
```
after:
```python
Batch(
    a: Batch(),
    b: array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
)
```

2. creating keys in a batch's subkey, e.g. 
```python
a = Batch(info={"key1": [0, 1], "key2": [2, 3]})
a[0] = Batch(info={"key1": 2, "key3": 4})
print(a)
```
before:
```python
Batch(
    info: Batch(
              key1: array([0, 1]),
              key2: array([0, 3]),
          ),
)
```
after:
```python
ValueError: Creating keys is not supported by item assignment.
```

3. small optimization for `Batch.stack_` and `Batch.cat_`