### PR TITLE
Trainer refactor : flexible logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ First, import some relevant packages:
 ```python
 import gym, torch, numpy as np, torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
-from tianshou.utils import BasicLogger
 import tianshou as ts
 ```
 
@@ -198,7 +197,7 @@ buffer_size = 20000
 eps_train, eps_test = 0.1, 0.05
 step_per_epoch, step_per_collect = 10000, 10
 writer = SummaryWriter('log/dqn')  # tensorboard is also supported!
-logger = BasicLogger(writer)
+logger = ts.utils.BasicLogger(writer)
 ```
 
 Make environments:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ First, import some relevant packages:
 ```python
 import gym, torch, numpy as np, torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
+from tianshou.utils import BasicLogger
 import tianshou as ts
 ```
 
@@ -197,6 +198,7 @@ buffer_size = 20000
 eps_train, eps_test = 0.1, 0.05
 step_per_epoch, step_per_collect = 10000, 10
 writer = SummaryWriter('log/dqn')  # tensorboard is also supported!
+logger = BasicLogger(writer)
 ```
 
 Make environments:
@@ -237,7 +239,7 @@ result = ts.trainer.offpolicy_trainer(
     train_fn=lambda epoch, env_step: policy.set_eps(eps_train),
     test_fn=lambda epoch, env_step: policy.set_eps(eps_test),
     stop_fn=lambda mean_rewards: mean_rewards >= env.spec.reward_threshold,
-    writer=writer)
+    logger=logger)
 print(f'Finished training! Use {result["duration"]}')
 ```
 

--- a/docs/contributor.rst
+++ b/docs/contributor.rst
@@ -7,3 +7,4 @@ We always welcome contributions to help make Tianshou better. Below are an incom
 * Minghao Zhang (`Mehooz <https://github.com/Mehooz>`_)
 * Alexis Duburcq (`duburcqa <https://github.com/duburcqa>`_)
 * Kaichao You (`youkaichao <https://github.com/youkaichao>`_)
+* Huayu Chen (`ChenDRAG <https://github.com/ChenDRAG>`_)

--- a/docs/tutorials/dqn.rst
+++ b/docs/tutorials/dqn.rst
@@ -130,7 +130,7 @@ Tianshou provides :func:`~tianshou.trainer.onpolicy_trainer`, :func:`~tianshou.t
         train_fn=lambda epoch, env_step: policy.set_eps(0.1),
         test_fn=lambda epoch, env_step: policy.set_eps(0.05),
         stop_fn=lambda mean_rewards: mean_rewards >= env.spec.reward_threshold,
-        writer=None)
+        logger=None)
     print(f'Finished training! Use {result["duration"]}')
 
 The meaning of each parameter is as follows (full description can be found at :func:`~tianshou.trainer.offpolicy_trainer`):
@@ -143,15 +143,17 @@ The meaning of each parameter is as follows (full description can be found at :f
 * ``train_fn``: A function receives the current number of epoch and step index, and performs some operations at the beginning of training in this epoch. For example, the code above means "reset the epsilon to 0.1 in DQN before training".
 * ``test_fn``: A function receives the current number of epoch and step index, and performs some operations at the beginning of testing in this epoch. For example, the code above means "reset the epsilon to 0.05 in DQN before testing".
 * ``stop_fn``: A function receives the average undiscounted returns of the testing result, return a boolean which indicates whether reaching the goal.
-* ``writer``: See below.
+* ``logger``: See below.
 
 The trainer supports `TensorBoard <https://www.tensorflow.org/tensorboard>`_ for logging. It can be used as:
 ::
 
     from torch.utils.tensorboard import SummaryWriter
+    from tianshou.utils import BasicLogger
     writer = SummaryWriter('log/dqn')
+    logger = BasicLogger(writer)
 
-Pass the writer into the trainer, and the training result will be recorded into the TensorBoard.
+Pass the logger into the trainer, and the training result will be recorded into the TensorBoard.
 
 The returned result is a dictionary as follows:
 ::

--- a/docs/tutorials/tictactoe.rst
+++ b/docs/tutorials/tictactoe.rst
@@ -176,6 +176,7 @@ So let's start to train our Tic-Tac-Toe agent! First, import some required modul
     import numpy as np
     from copy import deepcopy
     from torch.utils.tensorboard import SummaryWriter
+    from tianshou.utils import BasicLogger
 
     from tianshou.env import DummyVectorEnv
     from tianshou.utils.net.common import Net
@@ -322,8 +323,9 @@ With the above preparation, we are close to the first learned agent. The followi
     if not hasattr(args, 'writer'):
         log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
         writer = SummaryWriter(log_path)
+        logger=BasicLogger(writer)
     else:
-        writer = args.writer
+        logger = args.logger
 
     # ======== callback functions used during training =========
 
@@ -359,7 +361,7 @@ With the above preparation, we are close to the first learned agent. The followi
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
         stop_fn=stop_fn, save_fn=save_fn, update_per_step=args.update_per_step,
-        writer=writer, test_in_train=False, reward_metric=reward_metric)
+        logger=logger, test_in_train=False, reward_metric=reward_metric)
 
     agent = policy.policies[args.agent_id - 1]
     # let's watch the match!

--- a/docs/tutorials/tictactoe.rst
+++ b/docs/tutorials/tictactoe.rst
@@ -323,7 +323,7 @@ With the above preparation, we are close to the first learned agent. The followi
     if not hasattr(args, 'writer'):
         log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
         writer = SummaryWriter(log_path)
-        logger=BasicLogger(writer)
+        logger = BasicLogger(writer)
     else:
         logger = args.logger
 

--- a/docs/tutorials/tictactoe.rst
+++ b/docs/tutorials/tictactoe.rst
@@ -320,12 +320,10 @@ With the above preparation, we are close to the first learned agent. The followi
     train_collector.collect(n_step=args.batch_size * args.training_num)
 
     # ======== tensorboard logging setup =========
-    if not hasattr(args, 'writer'):
-        log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
-        writer = SummaryWriter(log_path)
-        logger = BasicLogger(writer)
-    else:
-        logger = args.logger
+    log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
+    writer = SummaryWriter(log_path)
+    writer.add_text("args", str(args))
+    logger = BasicLogger(writer)
 
     # ======== callback functions used during training =========
 

--- a/examples/atari/atari_bcq.py
+++ b/examples/atari/atari_bcq.py
@@ -119,7 +119,7 @@ def test_discrete_bcq(args=get_args()):
     log_path = os.path.join(args.logdir, args.task, 'bcq', 'seed_' + str(
         args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
     logger = BasicLogger(writer, update_interval=args.log_interval)
 
     def save_fn(policy):

--- a/examples/atari/atari_bcq.py
+++ b/examples/atari/atari_bcq.py
@@ -7,10 +7,10 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offline_trainer
 from tianshou.utils.net.discrete import Actor
-from tianshou.utils import BasicLogger
 from tianshou.policy import DiscreteBCQPolicy
 from tianshou.data import Collector, ReplayBuffer
 
@@ -116,10 +116,11 @@ def test_discrete_bcq(args=get_args()):
     test_collector = Collector(policy, test_envs, exploration_noise=True)
 
     # log
-    log_path = os.path.join(args.logdir, args.task, 'bcq', 'seed_' + str(
-        args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
+    log_path = os.path.join(
+        args.logdir, args.task, 'bcq',
+        f'seed_{args.seed}_{datetime.datetime.now().strftime("%m%d-%H%M%S")}')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    writer.add_text("args", str(args))
     logger = BasicLogger(writer, update_interval=args.log_interval)
 
     def save_fn(policy):

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -9,6 +9,7 @@ from tianshou.policy import C51Policy
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
+from tianshou.utils import BasicLogger
 
 from atari_network import C51
 from atari_wrapper import wrap_deepmind
@@ -98,6 +99,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -118,7 +120,7 @@ def test_c51(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        writer.add_scalar('train/eps', eps, global_step=env_step)
+        logger.write('train/eps', eps, env_step)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)
@@ -144,7 +146,7 @@ def test_c51(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer,
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step, test_in_train=False)
 
     pprint.pprint(result)

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -121,7 +121,7 @@ def test_c51(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        logger.write('train/eps', eps, env_step)
+        logger.write('train/eps', env_step, eps)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -6,10 +6,10 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import C51Policy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
-from tianshou.utils import BasicLogger
 
 from atari_network import C51
 from atari_wrapper import wrap_deepmind
@@ -99,6 +99,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
+    writer.add_text("args", str(args))
     logger = BasicLogger(writer)
 
     def save_fn(policy):

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -99,7 +99,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -9,6 +9,7 @@ from tianshou.policy import DQNPolicy
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
+from tianshou.utils import BasicLogger
 
 from atari_network import DQN
 from atari_wrapper import wrap_deepmind
@@ -94,7 +95,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -117,7 +117,7 @@ def test_dqn(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        logger.write('train/eps', eps, env_step)
+        logger.write('train/eps', env_step, eps)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -94,6 +94,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -114,7 +115,7 @@ def test_dqn(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        writer.add_scalar('train/eps', eps, global_step=env_step)
+        logger.write('train/eps', eps, env_step)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)
@@ -154,7 +155,7 @@ def test_dqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer,
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step, test_in_train=False)
 
     pprint.pprint(result)

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -6,10 +6,10 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
-from tianshou.utils import BasicLogger
 
 from atari_network import DQN
 from atari_wrapper import wrap_deepmind
@@ -95,6 +95,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
+    writer.add_text("args", str(args))
     logger = BasicLogger(writer)
 
     def save_fn(policy):

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -5,11 +5,11 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.policy import QRDQNPolicy
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
-from tianshou.utils import BasicLogger
 
 from atari_network import QRDQN
 from atari_wrapper import wrap_deepmind
@@ -97,6 +97,7 @@ def test_qrdqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'qrdqn')
     writer = SummaryWriter(log_path)
+    writer.add_text("args", str(args))
     logger = BasicLogger(writer)
 
     def save_fn(policy):

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -97,7 +97,7 @@ def test_qrdqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'qrdqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -9,6 +9,7 @@ from tianshou.policy import QRDQNPolicy
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
+from tianshou.utils import BasicLogger
 
 from atari_network import QRDQN
 from atari_wrapper import wrap_deepmind
@@ -96,6 +97,7 @@ def test_qrdqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'qrdqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -116,7 +118,7 @@ def test_qrdqn(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        writer.add_scalar('train/eps', eps, global_step=env_step)
+        logger.write('train/eps', eps, env_step)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)
@@ -142,7 +144,7 @@ def test_qrdqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer,
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step, test_in_train=False)
 
     pprint.pprint(result)

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -119,7 +119,7 @@ def test_qrdqn(args=get_args()):
         else:
             eps = args.eps_train_final
         policy.set_eps(eps)
-        logger.write('train/eps', eps, env_step)
+        logger.write('train/eps', env_step, eps)
 
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)

--- a/examples/atari/runnable/pong_a2c.py
+++ b/examples/atari/runnable/pong_a2c.py
@@ -10,6 +10,7 @@ from tianshou.utils.net.common import Net
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
+from tianshou.utils import BasicLogger
 
 from atari import create_atari_environment, preprocess_fn
 
@@ -79,7 +80,9 @@ def test_a2c(args=get_args()):
         preprocess_fn=preprocess_fn, exploration_noise=True)
     test_collector = Collector(policy, test_envs, preprocess_fn=preprocess_fn)
     # log
-    writer = SummaryWriter(os.path.join(args.logdir, args.task, 'a2c'))
+    log_path = os.path.join(args.logdir, args.task, 'a2c')
+    writer = SummaryWriter(log_path)
+    logger = BasicLogger(logger)
 
     def stop_fn(mean_rewards):
         if env.env.spec.reward_threshold:
@@ -91,7 +94,7 @@ def test_a2c(args=get_args()):
     result = onpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
-        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, writer=writer)
+        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, logger=logger)
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/examples/atari/runnable/pong_a2c.py
+++ b/examples/atari/runnable/pong_a2c.py
@@ -82,7 +82,7 @@ def test_a2c(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'a2c')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(logger)
+    logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         if env.env.spec.reward_threshold:

--- a/examples/atari/runnable/pong_a2c.py
+++ b/examples/atari/runnable/pong_a2c.py
@@ -4,13 +4,14 @@ import pprint
 import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
+
 from tianshou.policy import A2CPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
-from tianshou.utils import BasicLogger
 
 from atari import create_atari_environment, preprocess_fn
 

--- a/examples/atari/runnable/pong_ppo.py
+++ b/examples/atari/runnable/pong_ppo.py
@@ -8,6 +8,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import PPOPolicy
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
@@ -84,8 +85,9 @@ def test_ppo(args=get_args()):
         preprocess_fn=preprocess_fn, exploration_noise=True)
     test_collector = Collector(policy, test_envs, preprocess_fn=preprocess_fn)
     # log
-    writer = SummaryWriter(os.path.join(args.logdir, args.task, 'ppo'))
-
+    log_path = os.path.join(args.logdir, args.task, 'ppo')
+    writer = SummaryWriter(log_path)
+    logger = BasicLogger(logger)
     def stop_fn(mean_rewards):
         if env.env.spec.reward_threshold:
             return mean_rewards >= env.spec.reward_threshold
@@ -96,7 +98,7 @@ def test_ppo(args=get_args()):
     result = onpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
-        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, writer=writer)
+        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, logger=logger)
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/examples/atari/runnable/pong_ppo.py
+++ b/examples/atari/runnable/pong_ppo.py
@@ -6,12 +6,12 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import PPOPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
-from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
+from tianshou.data import Collector, VectorReplayBuffer
 
 from atari import create_atari_environment, preprocess_fn
 
@@ -100,6 +100,7 @@ def test_ppo(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, logger=logger)
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/examples/atari/runnable/pong_ppo.py
+++ b/examples/atari/runnable/pong_ppo.py
@@ -88,7 +88,7 @@ def test_ppo(args=get_args()):
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)
-    
+
     def stop_fn(mean_rewards):
         if env.env.spec.reward_threshold:
             return mean_rewards >= env.spec.reward_threshold

--- a/examples/atari/runnable/pong_ppo.py
+++ b/examples/atari/runnable/pong_ppo.py
@@ -87,7 +87,8 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(logger)
+    logger = BasicLogger(writer)
+    
     def stop_fn(mean_rewards):
         if env.env.spec.reward_threshold:
             return mean_rewards >= env.spec.reward_threshold

--- a/examples/box2d/acrobot_dualdqn.py
+++ b/examples/box2d/acrobot_dualdqn.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import DQNPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 
@@ -81,6 +82,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -106,7 +108,7 @@ def test_dqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/examples/box2d/acrobot_dualdqn.py
+++ b/examples/box2d/acrobot_dualdqn.py
@@ -82,7 +82,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/box2d/acrobot_dualdqn.py
+++ b/examples/box2d/acrobot_dualdqn.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 

--- a/examples/box2d/bipedal_hardcore_sac.py
+++ b/examples/box2d/bipedal_hardcore_sac.py
@@ -135,7 +135,7 @@ def test_sac_bipedal(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/box2d/bipedal_hardcore_sac.py
+++ b/examples/box2d/bipedal_hardcore_sac.py
@@ -7,12 +7,12 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import SACPolicy
+from tianshou.utils import BasicLogger
 from tianshou.utils.net.common import Net
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():

--- a/examples/box2d/bipedal_hardcore_sac.py
+++ b/examples/box2d/bipedal_hardcore_sac.py
@@ -12,6 +12,7 @@ from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -134,6 +135,7 @@ def test_sac_bipedal(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -146,7 +148,7 @@ def test_sac_bipedal(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, test_in_train=False,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger)
 
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/examples/box2d/lunarlander_dqn.py
+++ b/examples/box2d/lunarlander_dqn.py
@@ -8,6 +8,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv
@@ -83,6 +84,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -102,7 +104,7 @@ def test_dqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, stop_fn=stop_fn, train_fn=train_fn,
-        test_fn=test_fn, save_fn=save_fn, writer=writer)
+        test_fn=test_fn, save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/examples/box2d/lunarlander_dqn.py
+++ b/examples/box2d/lunarlander_dqn.py
@@ -84,7 +84,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/box2d/lunarlander_dqn.py
+++ b/examples/box2d/lunarlander_dqn.py
@@ -7,8 +7,8 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
-from tianshou.utils.net.common import Net
 from tianshou.utils import BasicLogger
+from tianshou.utils.net.common import Net
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv

--- a/examples/box2d/mcc_sac.py
+++ b/examples/box2d/mcc_sac.py
@@ -104,7 +104,7 @@ def test_sac(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/examples/box2d/mcc_sac.py
+++ b/examples/box2d/mcc_sac.py
@@ -13,6 +13,7 @@ from tianshou.env import DummyVectorEnv
 from tianshou.exploration import OUNoise
 from tianshou.utils.net.common import Net
 from tianshou.utils.net.continuous import ActorProb, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -103,6 +104,7 @@ def test_sac(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -115,7 +117,7 @@ def test_sac(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, stop_fn=stop_fn,
-        save_fn=save_fn, writer=writer)
+        save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/examples/box2d/mcc_sac.py
+++ b/examples/box2d/mcc_sac.py
@@ -7,13 +7,13 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import SACPolicy
-from tianshou.trainer import offpolicy_trainer
-from tianshou.data import Collector, VectorReplayBuffer
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.exploration import OUNoise
 from tianshou.utils.net.common import Net
+from tianshou.trainer import offpolicy_trainer
+from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -8,12 +8,12 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import SACPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -119,7 +119,7 @@ def test_sac(args=get_args()):
     log_path = os.path.join(args.logdir, args.task, 'sac', 'seed_' + str(
         args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    writer.add_text("args", str(args))
     logger = BasicLogger(writer, train_interval=args.log_interval)
 
     def watch():

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -2,6 +2,7 @@ import os
 import gym
 import torch
 import pprint
+import datetime
 import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
@@ -12,6 +13,7 @@ from tianshou.utils.net.common import Net
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -114,8 +116,11 @@ def test_sac(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    log_path = os.path.join(args.logdir, args.task, 'sac')
+    log_path = os.path.join(args.logdir, args.task, 'sac', 'seed_' + str(
+        args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
+    logger = BasicLogger(writer, train_interval=args.log_interval)
 
     def watch():
         # watch agent's performance
@@ -141,8 +146,8 @@ def test_sac(args=get_args()):
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, writer=writer,
-        update_per_step=args.update_per_step, log_interval=args.log_interval)
+        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
+        update_per_step=args.update_per_step)
     pprint.pprint(result)
     watch()
 

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -119,7 +119,7 @@ def test_sac(args=get_args()):
     log_path = os.path.join(args.logdir, args.task, 'sac', 'seed_' + str(
         args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
     logger = BasicLogger(writer, train_interval=args.log_interval)
 
     def watch():

--- a/examples/mujoco/runnable/ant_v2_ddpg.py
+++ b/examples/mujoco/runnable/ant_v2_ddpg.py
@@ -12,6 +12,7 @@ from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -79,7 +80,9 @@ def test_ddpg(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    writer = SummaryWriter(args.logdir + '/' + 'ddpg')
+    log_path = args.logdir + '/' + 'ddpg'
+    writer = SummaryWriter(log_path)
+    logger = BasicLoggerwri(writer)
 
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
@@ -88,7 +91,7 @@ def test_ddpg(args=get_args()):
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, writer=writer)
+        args.batch_size, stop_fn=stop_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/examples/mujoco/runnable/ant_v2_ddpg.py
+++ b/examples/mujoco/runnable/ant_v2_ddpg.py
@@ -82,7 +82,7 @@ def test_ddpg(args=get_args()):
     # log
     log_path = args.logdir + '/' + 'ddpg'
     writer = SummaryWriter(log_path)
-    logger = BasicLoggerwri(writer)
+    logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold

--- a/examples/mujoco/runnable/ant_v2_ddpg.py
+++ b/examples/mujoco/runnable/ant_v2_ddpg.py
@@ -1,3 +1,4 @@
+import os
 import gym
 import torch
 import pprint
@@ -6,13 +7,13 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DDPGPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
 from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -80,7 +81,7 @@ def test_ddpg(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    log_path = args.logdir + '/' + 'ddpg'
+    log_path = os.path.join(args.logdir, args.task, 'ddpg')
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)
 

--- a/examples/mujoco/runnable/ant_v2_td3.py
+++ b/examples/mujoco/runnable/ant_v2_td3.py
@@ -1,3 +1,4 @@
+import os
 import gym
 import torch
 import pprint
@@ -6,13 +7,13 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import TD3Policy
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
 from tianshou.exploration import GaussianNoise
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -89,7 +90,7 @@ def test_td3(args=get_args()):
     test_collector = Collector(policy, test_envs)
     # train_collector.collect(n_step=args.buffer_size)
     # log
-    log_path = args.logdir + '/' + 'td3'
+    log_path = os.path.join(args.logdir, args.task, 'td3')
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)
 

--- a/examples/mujoco/runnable/ant_v2_td3.py
+++ b/examples/mujoco/runnable/ant_v2_td3.py
@@ -93,7 +93,6 @@ def test_td3(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)
 
-
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
 

--- a/examples/mujoco/runnable/ant_v2_td3.py
+++ b/examples/mujoco/runnable/ant_v2_td3.py
@@ -12,6 +12,7 @@ from tianshou.exploration import GaussianNoise
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -88,7 +89,10 @@ def test_td3(args=get_args()):
     test_collector = Collector(policy, test_envs)
     # train_collector.collect(n_step=args.buffer_size)
     # log
-    writer = SummaryWriter(args.logdir + '/' + 'td3')
+    log_path = args.logdir + '/' + 'td3'
+    writer = SummaryWriter(log_path)
+    logger = BasicLogger(writer)
+
 
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
@@ -97,7 +101,7 @@ def test_td3(args=get_args()):
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, writer=writer)
+        args.batch_size, stop_fn=stop_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/examples/mujoco/runnable/halfcheetahBullet_v0_sac.py
+++ b/examples/mujoco/runnable/halfcheetahBullet_v0_sac.py
@@ -2,6 +2,7 @@ import os
 import gym
 import torch
 import pprint
+import datetime
 import argparse
 import numpy as np
 import pybullet_envs
@@ -13,6 +14,7 @@ from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -88,8 +90,10 @@ def test_sac(args=get_args()):
     test_collector = Collector(policy, test_envs)
     # train_collector.collect(n_step=args.buffer_size)
     # log
-    log_path = os.path.join(args.logdir, args.task, 'sac', args.run_id)
+    log_path = os.path.join(args.logdir, args.task, 'sac', 'seed_' + str(
+        args.seed) + '_' + datetime.datetime.now().strftime('%m%d-%H%M%S'))
     writer = SummaryWriter(log_path)
+    logger = BasicLogger(writer, train_interval=args.log_interval)
 
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
@@ -99,7 +103,7 @@ def test_sac(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, stop_fn=stop_fn,
-        writer=writer, log_interval=args.log_interval)
+        logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/examples/mujoco/runnable/halfcheetahBullet_v0_sac.py
+++ b/examples/mujoco/runnable/halfcheetahBullet_v0_sac.py
@@ -9,12 +9,12 @@ import pybullet_envs
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import SACPolicy
+from tianshou.utils import BasicLogger
 from tianshou.utils.net.common import Net
 from tianshou.env import SubprocVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
-from tianshou.utils import BasicLogger
 
 
 def get_args():

--- a/examples/mujoco/runnable/point_maze_td3.py
+++ b/examples/mujoco/runnable/point_maze_td3.py
@@ -12,6 +12,7 @@ from tianshou.exploration import GaussianNoise
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
+from tianshou.utils import BasicLogger
 
 from mujoco.register import reg
 
@@ -93,7 +94,9 @@ def test_td3(args=get_args()):
     test_collector = Collector(policy, test_envs)
     # train_collector.collect(n_step=args.buffer_size)
     # log
-    writer = SummaryWriter(args.logdir + '/' + 'td3')
+    log_path = args.logdir + '/' + 'td3'
+    writer = SummaryWriter(log_path)
+    logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         if env.spec.reward_threshold:
@@ -105,7 +108,7 @@ def test_td3(args=get_args()):
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, writer=writer)
+        args.batch_size, stop_fn=stop_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/examples/mujoco/runnable/point_maze_td3.py
+++ b/examples/mujoco/runnable/point_maze_td3.py
@@ -1,3 +1,4 @@
+import os
 import gym
 import torch
 import pprint
@@ -6,13 +7,13 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import TD3Policy
+from tianshou.utils import BasicLogger
 from tianshou.utils.net.common import Net
 from tianshou.env import SubprocVectorEnv
 from tianshou.exploration import GaussianNoise
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import Actor, Critic
-from tianshou.utils import BasicLogger
 
 from mujoco.register import reg
 
@@ -94,7 +95,7 @@ def test_td3(args=get_args()):
     test_collector = Collector(policy, test_envs)
     # train_collector.collect(n_step=args.buffer_size)
     # log
-    log_path = args.logdir + '/' + 'td3'
+    log_path = os.path.join(args.logdir, args.task, 'td3')
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)
 

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -12,6 +12,7 @@ from tianshou.data import (
     VectorReplayBuffer,
     CachedReplayBuffer,
 )
+from tianshou.utils import BasicLogger
 
 if __name__ == '__main__':
     from env import MyTestEnv
@@ -56,7 +57,7 @@ class Logger:
             info = kwargs['info']
             info.rew = kwargs['rew']
             if 'key' in info.keys():
-                self.writer.add_scalar(
+                self.writer.add_scalar(# TODO
                     'key', np.mean(info.key), global_step=self.cnt)
             self.cnt += 1
             return Batch(info=info)
@@ -75,6 +76,7 @@ class Logger:
 
 
 def test_collector():
+    # TODO
     writer = SummaryWriter('log/collector')
     logger = Logger(writer)
     env_fns = [lambda x=i: MyTestEnv(size=x, sleep=0) for i in [2, 3, 4, 5]]

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -12,7 +12,6 @@ from tianshou.data import (
     VectorReplayBuffer,
     CachedReplayBuffer,
 )
-from tianshou.utils import BasicLogger
 
 if __name__ == '__main__':
     from env import MyTestEnv
@@ -57,7 +56,7 @@ class Logger:
             info = kwargs['info']
             info.rew = kwargs['rew']
             if 'key' in info.keys():
-                self.writer.add_scalar(# TODO
+                self.writer.add_scalar(
                     'key', np.mean(info.key), global_step=self.cnt)
             self.cnt += 1
             return Batch(info=info)
@@ -76,7 +75,6 @@ class Logger:
 
 
 def test_collector():
-    # TODO
     writer = SummaryWriter('log/collector')
     logger = Logger(writer)
     env_fns = [lambda x=i: MyTestEnv(size=x, sleep=0) for i in [2, 3, 4, 5]]

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -2,7 +2,6 @@ import torch
 import numpy as np
 
 from tianshou.utils import MovAvg
-from tianshou.utils import SummaryWriter
 from tianshou.utils.net.common import MLP, Net
 from tianshou.exploration import GaussianNoise, OUNoise
 from tianshou.utils.net.continuous import RecurrentActorProb, RecurrentCritic
@@ -77,25 +76,7 @@ def test_net():
     assert list(net(data, act).shape) == [bsz, 1]
 
 
-def test_summary_writer():
-    # get first instance by key of `default` or your own key
-    writer1 = SummaryWriter.get_instance(
-        key="first", log_dir="log/test_sw/first")
-    assert writer1.log_dir == "log/test_sw/first"
-    writer2 = SummaryWriter.get_instance()
-    assert writer1 is writer2
-    # create new instance by specify a new key
-    writer3 = SummaryWriter.get_instance(
-        key="second", log_dir="log/test_sw/second")
-    assert writer3.log_dir == "log/test_sw/second"
-    writer4 = SummaryWriter.get_instance(key="second")
-    assert writer3 is writer4
-    assert writer1 is not writer3
-    assert writer1.log_dir != writer4.log_dir
-
-
 if __name__ == '__main__':
     test_noise()
     test_moving_average()
     test_net()
-    test_summary_writer()

--- a/test/continuous/test_ddpg.py
+++ b/test/continuous/test_ddpg.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DDPGPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer

--- a/test/continuous/test_ddpg.py
+++ b/test/continuous/test_ddpg.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import DDPGPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer
@@ -93,6 +94,7 @@ def test_ddpg(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ddpg')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -105,7 +107,7 @@ def test_ddpg(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, stop_fn=stop_fn,
-        save_fn=save_fn, writer=writer)
+        save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/continuous/test_ddpg.py
+++ b/test/continuous/test_ddpg.py
@@ -94,7 +94,7 @@ def test_ddpg(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ddpg')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -10,6 +10,7 @@ from torch.distributions import Independent, Normal
 from tianshou.policy import PPOPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic
@@ -111,6 +112,7 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -123,7 +125,7 @@ def test_ppo(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
-        writer=writer)
+        logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -112,7 +112,7 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -8,9 +8,9 @@ from torch.utils.tensorboard import SummaryWriter
 from torch.distributions import Independent, Normal
 
 from tianshou.policy import PPOPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.continuous import ActorProb, Critic

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -103,7 +103,7 @@ def test_sac_with_il(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -8,6 +8,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import SACPolicy, ImitationPolicy
@@ -102,6 +103,7 @@ def test_sac_with_il(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'sac')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -114,7 +116,7 @@ def test_sac_with_il(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, stop_fn=stop_fn,
-        save_fn=save_fn, writer=writer)
+        save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)
@@ -146,7 +148,7 @@ def test_sac_with_il(args=get_args()):
     result = offpolicy_trainer(
         il_policy, train_collector, il_test_collector, args.epoch,
         args.il_step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -6,9 +6,9 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import SACPolicy, ImitationPolicy

--- a/test/continuous/test_td3.py
+++ b/test/continuous/test_td3.py
@@ -107,7 +107,7 @@ def test_td3(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'td3')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/continuous/test_td3.py
+++ b/test/continuous/test_td3.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import TD3Policy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer
@@ -106,6 +107,7 @@ def test_td3(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'td3')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -118,7 +120,7 @@ def test_td3(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num, args.batch_size,
         update_per_step=args.update_per_step, stop_fn=stop_fn,
-        save_fn=save_fn, writer=writer)
+        save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/continuous/test_td3.py
+++ b/test/continuous/test_td3.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import TD3Policy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.exploration import GaussianNoise
 from tianshou.data import Collector, VectorReplayBuffer

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -6,9 +6,9 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
 from tianshou.policy import A2CPolicy, ImitationPolicy

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -8,6 +8,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
 from tianshou.policy import A2CPolicy, ImitationPolicy
@@ -89,6 +90,7 @@ def test_a2c_with_il(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'a2c')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -101,7 +103,7 @@ def test_a2c_with_il(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
-        writer=writer)
+        logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)
@@ -130,7 +132,7 @@ def test_a2c_with_il(args=get_args()):
     result = offpolicy_trainer(
         il_policy, train_collector, il_test_collector, args.epoch,
         args.il_step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -90,7 +90,7 @@ def test_a2c_with_il(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'a2c')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import C51Policy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 
@@ -89,6 +90,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -115,7 +117,7 @@ def test_c51(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -90,7 +90,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import C51Policy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -92,7 +92,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -10,6 +10,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import DQNPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 
@@ -91,6 +92,7 @@ def test_dqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'dqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -117,7 +119,7 @@ def test_dqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
-        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
 

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -8,9 +8,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 

--- a/test/discrete/test_drqn.py
+++ b/test/discrete/test_drqn.py
@@ -7,10 +7,10 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import DQNPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.utils.net.common import Recurrent
-from tianshou.utils import BasicLogger
 from tianshou.data import Collector, VectorReplayBuffer
 
 

--- a/test/discrete/test_drqn.py
+++ b/test/discrete/test_drqn.py
@@ -10,6 +10,7 @@ from tianshou.policy import DQNPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.trainer import offpolicy_trainer
 from tianshou.utils.net.common import Recurrent
+from tianshou.utils import BasicLogger
 from tianshou.data import Collector, VectorReplayBuffer
 
 
@@ -77,6 +78,7 @@ def test_drqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'drqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -96,7 +98,7 @@ def test_drqn(args=get_args()):
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step,
         train_fn=train_fn, test_fn=test_fn, stop_fn=stop_fn,
-        save_fn=save_fn, writer=writer)
+        save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/test/discrete/test_drqn.py
+++ b/test/discrete/test_drqn.py
@@ -78,7 +78,7 @@ def test_drqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'drqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -10,6 +10,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.data import Collector
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offline_trainer
 from tianshou.policy import DiscreteBCQPolicy
 
@@ -82,6 +83,7 @@ def test_discrete_bcq(args=get_args()):
 
     log_path = os.path.join(args.logdir, args.task, 'discrete_bcq')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -92,7 +94,7 @@ def test_discrete_bcq(args=get_args()):
     result = offline_trainer(
         policy, buffer, test_collector,
         args.epoch, args.update_per_epoch, args.test_num, args.batch_size,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer)
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger)
 
     assert stop_fn(result['best_reward'])
 

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -8,9 +8,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.data import Collector
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offline_trainer
 from tianshou.policy import DiscreteBCQPolicy
 

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -83,7 +83,7 @@ def test_discrete_bcq(args=get_args()):
 
     log_path = os.path.join(args.logdir, args.task, 'discrete_bcq')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_pg.py
+++ b/test/discrete/test_pg.py
@@ -73,7 +73,7 @@ def test_pg(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'pg')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_pg.py
+++ b/test/discrete/test_pg.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import PGPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 
@@ -72,6 +73,7 @@ def test_pg(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'pg')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -84,7 +86,7 @@ def test_pg(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
-        writer=writer)
+        logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/discrete/test_pg.py
+++ b/test/discrete/test_pg.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import PGPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 

--- a/test/discrete/test_ppo.py
+++ b/test/discrete/test_ppo.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import PPOPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic
@@ -98,6 +99,7 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -110,7 +112,7 @@ def test_ppo(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
-        writer=writer)
+        logger=logger)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':
         pprint.pprint(result)

--- a/test/discrete/test_ppo.py
+++ b/test/discrete/test_ppo.py
@@ -99,7 +99,7 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_ppo.py
+++ b/test/discrete/test_ppo.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import PPOPolicy
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.utils.net.discrete import Actor, Critic

--- a/test/discrete/test_qrdqn.py
+++ b/test/discrete/test_qrdqn.py
@@ -88,7 +88,7 @@ def test_qrdqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'qrdqn')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_qrdqn.py
+++ b/test/discrete/test_qrdqn.py
@@ -9,6 +9,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.policy import QRDQNPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
+from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 
@@ -87,6 +88,7 @@ def test_qrdqn(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'qrdqn')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -113,7 +115,7 @@ def test_qrdqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, writer=writer,
+        stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step)
 
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_qrdqn.py
+++ b/test/discrete/test_qrdqn.py
@@ -6,10 +6,10 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.policy import QRDQNPolicy
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.utils import BasicLogger
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer, PrioritizedVectorReplayBuffer
 

--- a/test/discrete/test_sac.py
+++ b/test/discrete/test_sac.py
@@ -100,7 +100,7 @@ def test_discrete_sac(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'discrete_sac')
     writer = SummaryWriter(log_path)
-    logger=BasicLogger(writer)
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_sac.py
+++ b/test/discrete/test_sac.py
@@ -12,6 +12,7 @@ from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import DiscreteSACPolicy
 from tianshou.utils.net.discrete import Actor, Critic
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -99,6 +100,7 @@ def test_discrete_sac(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'discrete_sac')
     writer = SummaryWriter(log_path)
+    logger=BasicLogger(writer)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
@@ -110,7 +112,7 @@ def test_discrete_sac(args=get_args()):
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
-        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, writer=writer,
+        args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step, test_in_train=False)
     assert stop_fn(result['best_reward'])
     if __name__ == '__main__':

--- a/test/discrete/test_sac.py
+++ b/test/discrete/test_sac.py
@@ -6,13 +6,13 @@ import argparse
 import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.env import SubprocVectorEnv
 from tianshou.utils.net.common import Net
-from tianshou.trainer import offpolicy_trainer
-from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import DiscreteSACPolicy
+from tianshou.trainer import offpolicy_trainer
 from tianshou.utils.net.discrete import Actor, Critic
-from tianshou.utils import BasicLogger
+from tianshou.data import Collector, VectorReplayBuffer
 
 
 def get_args():

--- a/test/modelbase/test_psrl.py
+++ b/test/modelbase/test_psrl.py
@@ -7,10 +7,10 @@ import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.policy import PSRLPolicy
+# from tianshou.utils import BasicLogger
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv
-from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -70,7 +70,8 @@ def test_psrl(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'psrl')
     writer = SummaryWriter(log_path)
-    args.logger = BasicLogger(writer)
+    writer.add_text("args", str(args))
+    # logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         if env.spec.reward_threshold:

--- a/test/modelbase/test_psrl.py
+++ b/test/modelbase/test_psrl.py
@@ -67,7 +67,6 @@ def test_psrl(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    #TODO
     log_path = args.logdir + '/' + args.task
     writer = SummaryWriter(log_path)
     logger = BasicLogger(writer)

--- a/test/modelbase/test_psrl.py
+++ b/test/modelbase/test_psrl.py
@@ -9,6 +9,7 @@ from tianshou.policy import PSRLPolicy
 from tianshou.trainer import onpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv
+from tianshou.utils import BasicLogger
 
 
 def get_args():
@@ -66,7 +67,10 @@ def test_psrl(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    writer = SummaryWriter(args.logdir + '/' + args.task)
+    #TODO
+    log_path = args.logdir + '/' + args.task
+    writer = SummaryWriter(log_path)
+    logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         if env.spec.reward_threshold:
@@ -79,7 +83,7 @@ def test_psrl(args=get_args()):
     result = onpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, 1, args.test_num, 0,
-        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, writer=writer,
+        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, logger=logger,
         test_in_train=False)
 
     if __name__ == '__main__':

--- a/test/modelbase/test_psrl.py
+++ b/test/modelbase/test_psrl.py
@@ -1,3 +1,4 @@
+import os
 import gym
 import torch
 import pprint
@@ -67,9 +68,9 @@ def test_psrl(args=get_args()):
         exploration_noise=True)
     test_collector = Collector(policy, test_envs)
     # log
-    log_path = args.logdir + '/' + args.task
+    log_path = os.path.join(args.logdir, args.task, 'psrl')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    args.logger = BasicLogger(writer)
 
     def stop_fn(mean_rewards):
         if env.spec.reward_threshold:
@@ -78,11 +79,12 @@ def test_psrl(args=get_args()):
             return False
 
     train_collector.collect(n_step=args.buffer_size, random=True)
-    # trainer
+    # trainer, test it without logger
     result = onpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, 1, args.test_num, 0,
-        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, logger=logger,
+        episode_per_collect=args.episode_per_collect, stop_fn=stop_fn,
+        # logger=logger,
         test_in_train=False)
 
     if __name__ == '__main__':

--- a/test/multiagent/Gomoku.py
+++ b/test/multiagent/Gomoku.py
@@ -7,6 +7,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tianshou.env import DummyVectorEnv
 from tianshou.data import Collector
 from tianshou.policy import RandomPolicy
+from tianshou.utils import BasicLogger
 
 from tic_tac_toe_env import TicTacToeEnv
 from tic_tac_toe import get_parser, get_agents, train_agent, watch
@@ -31,7 +32,8 @@ def gomoku(args=get_args()):
 
     # log
     log_path = os.path.join(args.logdir, 'Gomoku', 'dqn')
-    args.writer = SummaryWriter(log_path)
+    writer = SummaryWriter(log_path)
+    args.logger = BasicLogger(writer)
 
     opponent_pool = [agent_opponent]
 

--- a/test/multiagent/tic_tac_toe.py
+++ b/test/multiagent/tic_tac_toe.py
@@ -6,13 +6,13 @@ from copy import deepcopy
 from typing import Optional, Tuple
 from torch.utils.tensorboard import SummaryWriter
 
+from tianshou.utils import BasicLogger
 from tianshou.env import DummyVectorEnv
 from tianshou.utils.net.common import Net
 from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import BasePolicy, DQNPolicy, RandomPolicy, \
     MultiAgentPolicyManager
-from tianshou.utils import BasicLogger
 
 from tic_tac_toe_env import TicTacToeEnv
 
@@ -132,13 +132,10 @@ def train_agent(
     # policy.set_eps(1)
     train_collector.collect(n_step=args.batch_size * args.training_num)
     # log
-    if not hasattr(args, 'logger'):
-        log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
-        writer = SummaryWriter(log_path)
-        logger = BasicLogger(writer)
-        args.logger = logger
-    else:
-        logger = args.logger
+    log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
+    writer = SummaryWriter(log_path)
+    writer.add_text("args", str(args))
+    logger = BasicLogger(writer)
 
     def save_fn(policy):
         if hasattr(args, 'model_save_path'):

--- a/test/multiagent/tic_tac_toe.py
+++ b/test/multiagent/tic_tac_toe.py
@@ -135,7 +135,7 @@ def train_agent(
     if not hasattr(args, 'logger'):
         log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
         writer = SummaryWriter(log_path)
-        logger=BasicLogger(writer)
+        logger = BasicLogger(writer)
         args.logger = logger
     else:
         logger = args.logger

--- a/test/multiagent/tic_tac_toe.py
+++ b/test/multiagent/tic_tac_toe.py
@@ -12,6 +12,7 @@ from tianshou.trainer import offpolicy_trainer
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import BasePolicy, DQNPolicy, RandomPolicy, \
     MultiAgentPolicyManager
+from tianshou.utils import BasicLogger
 
 from tic_tac_toe_env import TicTacToeEnv
 
@@ -131,12 +132,13 @@ def train_agent(
     # policy.set_eps(1)
     train_collector.collect(n_step=args.batch_size * args.training_num)
     # log
-    if not hasattr(args, 'writer'):
+    if not hasattr(args, 'logger'):
         log_path = os.path.join(args.logdir, 'tic_tac_toe', 'dqn')
         writer = SummaryWriter(log_path)
-        args.writer = writer
+        logger=BasicLogger(writer)
+        args.logger = logger
     else:
-        writer = args.writer
+        logger = args.logger
 
     def save_fn(policy):
         if hasattr(args, 'model_save_path'):
@@ -166,7 +168,7 @@ def train_agent(
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
         stop_fn=stop_fn, save_fn=save_fn, update_per_step=args.update_per_step,
-        writer=writer, test_in_train=False, reward_metric=reward_metric)
+        logger=logger, test_in_train=False, reward_metric=reward_metric)
 
     return result, policy.policies[args.agent_id - 1]
 

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -92,8 +92,6 @@ class ReplayBuffer:
         ("buffer.__getattr__" is customized).
         """
         self.__dict__.update(state)
-        # compatible with version == 0.3.1's HDF5 data format
-        self._indices = np.arange(self.maxsize)
 
     def __setattr__(self, key: str, value: Any) -> None:
         """Set self.key = value."""

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -184,9 +184,9 @@ class Collector(object):
 
             * ``n/ep`` collected number of episodes.
             * ``n/st`` collected number of steps.
-            * ``rews`` list of episode reward over collected episodes.
-            * ``lens`` list of episode length over collected episodes.
-            * ``idxs`` list of episode start index in buffer over collected episodes.
+            * ``rews`` array of episode reward over collected episodes.
+            * ``lens`` array of episode length over collected episodes.
+            * ``idxs`` array of episode start index in buffer over collected episodes.
         """
         assert not self.env.is_async, "Please use AsyncCollector if using async venv."
         if n_step is not None:
@@ -379,9 +379,9 @@ class AsyncCollector(Collector):
 
             * ``n/ep`` collected number of episodes.
             * ``n/st`` collected number of steps.
-            * ``rews`` list of episode reward over collected episodes.
-            * ``lens`` list of episode length over collected episodes.
-            * ``idxs`` list of episode start index in buffer over collected episodes.
+            * ``rews`` array of episode reward over collected episodes.
+            * ``lens`` array of episode length over collected episodes.
+            * ``idxs`` array of episode start index in buffer over collected episodes.
         """
         # collect at least n_step or n_episode
         if n_step is not None:

--- a/tianshou/policy/base.py
+++ b/tianshou/policy/base.py
@@ -4,7 +4,7 @@ import numpy as np
 from torch import nn
 from numba import njit
 from abc import ABC, abstractmethod
-from typing import Any, List, Union, Mapping, Optional, Callable
+from typing import Any, Dict, Union, Optional, Callable
 
 from tianshou.data import Batch, ReplayBuffer, to_torch_as, to_numpy
 
@@ -124,12 +124,10 @@ class BasePolicy(ABC, nn.Module):
         return batch
 
     @abstractmethod
-    def learn(
-        self, batch: Batch, **kwargs: Any
-    ) -> Mapping[str, Union[float, List[float]]]:
+    def learn(self, batch: Batch, **kwargs: Any) -> Dict[str, Any]:
         """Update policy with a given batch of data.
 
-        :return: A dict which includes loss and its corresponding label.
+        :return: A dict, including the data needed to be logged (e.g., loss).
 
         .. note::
 
@@ -162,18 +160,20 @@ class BasePolicy(ABC, nn.Module):
 
     def update(
         self, sample_size: int, buffer: Optional[ReplayBuffer], **kwargs: Any
-    ) -> Mapping[str, Union[float, List[float]]]:
+    ) -> Dict[str, Any]:
         """Update the policy network and replay buffer.
 
-        It includes 3 function steps: process_fn, learn, and post_process_fn.
-        In addition, this function will change the value of ``self.updating``:
-        it will be False before this function and will be True when executing
-        :meth:`update`. Please refer to :ref:`policy_state` for more detailed
-        explanation.
+        It includes 3 function steps: process_fn, learn, and post_process_fn. In
+        addition, this function will change the value of ``self.updating``: it will be
+        False before this function and will be True when executing :meth:`update`.
+        Please refer to :ref:`policy_state` for more detailed explanation.
 
-        :param int sample_size: 0 means it will extract all the data from the
-            buffer, otherwise it will sample a batch with given sample_size.
+        :param int sample_size: 0 means it will extract all the data from the buffer,
+            otherwise it will sample a batch with given sample_size.
         :param ReplayBuffer buffer: the corresponding replay buffer.
+
+        :return: A dict, including the data needed to be logged (e.g., loss) from
+            ``policy.learn()``.
         """
         if buffer is None:
             return {}

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -2,11 +2,10 @@ import time
 import tqdm
 import numpy as np
 from collections import defaultdict
-from torch.utils.tensorboard import SummaryWriter
 from typing import Dict, Union, Callable, Optional
 
 from tianshou.policy import BasePolicy
-from tianshou.utils import tqdm_config, MovAvg
+from tianshou.utils import tqdm_config, MovAvg, BaseLogger, LazyLogger
 from tianshou.data import Collector, ReplayBuffer
 from tianshou.trainer import test_episode, gather_info
 
@@ -23,8 +22,7 @@ def offline_trainer(
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-    writer: Optional[SummaryWriter] = None,
-    log_interval: int = 1,
+    logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
 ) -> Dict[str, Union[float, str]]:
     """A wrapper for offline trainer procedure.
@@ -67,10 +65,9 @@ def offline_trainer(
     start_time = time.time()
     test_collector.reset_stat()
     test_result = test_episode(policy, test_collector, test_fn, 0, episode_per_test,
-                               writer, gradient_step, reward_metric)
+                               logger, gradient_step, reward_metric)
     best_epoch = 0
-    best_reward = test_result["rews"].mean()
-    best_reward_std = test_result["rews"].std()
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
     for epoch in range(1, 1 + max_epoch):
         policy.train()
         with tqdm.trange(
@@ -83,24 +80,22 @@ def offline_trainer(
                 for k in losses.keys():
                     stat[k].add(losses[k])
                     data[k] = f"{stat[k].get():.6f}"
-                    if writer and gradient_step % log_interval == 0:
-                        writer.add_scalar(
-                            "train/" + k, stat[k].get(),
-                            global_step=gradient_step)
+                    for k in losses.keys():
+                        losses[k] = stat[k].get()
+                    logger.log_update_data(losses, gradient_step)
                 t.set_postfix(**data)
         # test
         test_result = test_episode(policy, test_collector, test_fn, epoch,
-                                   episode_per_test, writer, gradient_step,
+                                   episode_per_test, logger, gradient_step,
                                    reward_metric)
-        if best_epoch == -1 or best_reward < test_result["rews"].mean():
-            best_reward = test_result["rews"].mean()
-            best_reward_std = test_result['rews'].std()
+        if best_epoch == -1 or best_reward < test_result["rew"]:
+            best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
             best_epoch = epoch
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(f"Epoch #{epoch}: test_reward: {test_result['rews'].mean():.6f} ± "
-                  f"{test_result['rews'].std():.6f}, best_reward: {best_reward:.6f} ± "
+            print(f"Epoch #{epoch}: test_reward: {test_result['rew']:.6f} ± "
+                  f"{test_result['rew_std']:.6f}, best_reward: {best_reward:.6f} ± "
                   f"{best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -53,8 +53,8 @@ def offline_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param BaseLogger logger: A logger that logs statistics during 
-        training/testing/updating. Default to a logger that doesn't log anything.
+    :param BaseLogger logger: A logger that logs statistics during updating/testing.
+        Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
 
     :return: See :func:`~tianshou.trainer.gather_info`.

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -78,25 +78,24 @@ def offline_trainer(
                 data = {"gradient_step": str(gradient_step)}
                 for k in losses.keys():
                     stat[k].add(losses[k])
-                    data[k] = f"{stat[k].get():.6f}"
-                    for k in losses.keys():
-                        losses[k] = stat[k].get()
-                    logger.log_update_data(losses, gradient_step)
+                    losses[k] = stat[k].get()
+                    data[k] = f"{losses[k]:.6f}"
+                logger.log_update_data(losses, gradient_step)
                 t.set_postfix(**data)
         # test
-        test_result = test_episode(policy, test_collector, test_fn, epoch,
-                                   episode_per_test, logger, gradient_step,
-                                   reward_metric)
-        if best_epoch == -1 or best_reward < test_result["rew"]:
-            best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
+        test_result = test_episode(
+            policy, test_collector, test_fn, epoch, episode_per_test,
+            logger, gradient_step, reward_metric)
+        rew, rew_std = test_result["rew"], test_result["rew_std"]
+        if best_epoch == -1 or best_reward < rew:
+            best_reward, best_reward_std = rew, rew_std
             best_epoch = epoch
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(f"Epoch #{epoch}: test_reward: {test_result['rew']:.6f} ± "
-                  f"{test_result['rew_std']:.6f}, best_reward: {best_reward:.6f} ± "
-                  f"{best_reward_std:.6f} in #{best_epoch}")
+            print(
+                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
+                f" {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break
-    return gather_info(start_time, None, test_collector,
-                       best_reward, best_reward_std)
+    return gather_info(start_time, None, test_collector, best_reward, best_reward_std)

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -93,9 +93,8 @@ def offline_trainer(
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(
-                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
-                f" {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
+            print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
+                  f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break
     return gather_info(start_time, None, test_collector, best_reward, best_reward_std)

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -53,9 +53,8 @@ def offline_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param torch.utils.tensorboard.SummaryWriter writer: a TensorBoard SummaryWriter;
-        if None is given, it will not write logs to TensorBoard. Default to None.
-    :param int log_interval: the log interval of the writer. Default to 1.
+    :param BaseLogger logger: A logger that logs statistics during 
+        training/testing/updating. Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
 
     :return: See :func:`~tianshou.trainer.gather_info`.

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -145,9 +145,8 @@ def offpolicy_trainer(
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(
-                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
-                f" {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
+            print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
+                  f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break
     return gather_info(start_time, train_collector, test_collector,

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -29,7 +29,6 @@ def offpolicy_trainer(
     verbose: bool = True,
     test_in_train: bool = True,
 ) -> Dict[str, Union[float, str]]:
-    # TODO doc test
     """A wrapper for off-policy trainer procedure.
 
     The "step" in trainer means an environment step (a.k.a. transition).
@@ -69,9 +68,8 @@ def offpolicy_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param torch.utils.tensorboard.SummaryWriter writer: a TensorBoard SummaryWriter;
-        if None is given, it will not write logs to TensorBoard. Default to None.
-    :param int log_interval: the log interval of the writer. Default to 1.
+    :param BaseLogger logger: A logger that logs statistics during 
+        training/testing/updating. Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
     :param bool test_in_train: whether to test in the training phase. Default to True.
 

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -2,12 +2,11 @@ import time
 import tqdm
 import numpy as np
 from collections import defaultdict
-from torch.utils.tensorboard import SummaryWriter
 from typing import Dict, Union, Callable, Optional
 
 from tianshou.data import Collector
 from tianshou.policy import BasePolicy
-from tianshou.utils import tqdm_config, MovAvg
+from tianshou.utils import tqdm_config, MovAvg, BaseLogger, LazyLogger
 from tianshou.trainer import test_episode, gather_info
 
 
@@ -26,11 +25,11 @@ def offpolicy_trainer(
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-    writer: Optional[SummaryWriter] = None,
-    log_interval: int = 1,
+    logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
     test_in_train: bool = True,
 ) -> Dict[str, Union[float, str]]:
+    # TODO doc test
     """A wrapper for off-policy trainer procedure.
 
     The "step" in trainer means an environment step (a.k.a. transition).
@@ -79,16 +78,16 @@ def offpolicy_trainer(
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
     env_step, gradient_step = 0, 0
+    last_rew, last_len = 0.0, 0
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     train_collector.reset_stat()
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
     test_result = test_episode(policy, test_collector, test_fn, 0, episode_per_test,
-                               writer, env_step, reward_metric)
+                               logger, env_step, reward_metric)
     best_epoch = 0
-    best_reward = test_result["rews"].mean()
-    best_reward_std = test_result["rews"].std()
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
     for epoch in range(1, 1 + max_epoch):
         # train
         policy.train()
@@ -99,34 +98,32 @@ def offpolicy_trainer(
                 if train_fn:
                     train_fn(epoch, env_step)
                 result = train_collector.collect(n_step=step_per_collect)
-                if len(result["rews"]) > 0 and reward_metric:
+                if result["n/ep"] > 0 and reward_metric:
                     result["rews"] = reward_metric(result["rews"])
                 env_step += int(result["n/st"])
                 t.update(result["n/st"])
+                logger.log_train_data(result, env_step)
+                last_rew = result['rew'] if 'rew' in result else last_rew
+                last_len = result['len'] if 'len' in result else last_len
                 data = {
                     "env_step": str(env_step),
-                    "rew": f"{result['rews'].mean():.2f}",
-                    "len": str(result["lens"].mean()),
+                    "rew": f"{last_rew:.2f}",
+                    "len": str(last_len),
                     "n/ep": str(int(result["n/ep"])),
                     "n/st": str(int(result["n/st"])),
                 }
                 if result["n/ep"] > 0:
-                    if writer and env_step % log_interval == 0:
-                        writer.add_scalar(
-                            "train/rew", result['rews'].mean(), global_step=env_step)
-                        writer.add_scalar(
-                            "train/len", result['lens'].mean(), global_step=env_step)
-                    if test_in_train and stop_fn and stop_fn(result["rews"].mean()):
+                    if test_in_train and stop_fn and stop_fn(result["rew"]):
                         test_result = test_episode(
                             policy, test_collector, test_fn,
-                            epoch, episode_per_test, writer, env_step)
-                        if stop_fn(test_result["rews"].mean()):
+                            epoch, episode_per_test, logger, env_step)
+                        if stop_fn(test_result["rew"]):
                             if save_fn:
                                 save_fn(policy)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,
-                                test_result["rews"].mean(), test_result["rews"].std())
+                                test_result["rew"], test_result["rew_std"])
                         else:
                             policy.train()
                 for i in range(round(update_per_step * result["n/st"])):
@@ -135,24 +132,23 @@ def offpolicy_trainer(
                     for k in losses.keys():
                         stat[k].add(losses[k])
                         data[k] = f"{stat[k].get():.6f}"
-                        if writer and gradient_step % log_interval == 0:
-                            writer.add_scalar(
-                                k, stat[k].get(), global_step=gradient_step)
+                    for k in losses.keys():
+                        losses[k] = stat[k].get()
+                    logger.log_update_data(losses, gradient_step)
                     t.set_postfix(**data)
             if t.n <= t.total:
                 t.update()
         # test
         test_result = test_episode(policy, test_collector, test_fn, epoch,
-                                   episode_per_test, writer, env_step, reward_metric)
-        if best_epoch == -1 or best_reward < test_result["rews"].mean():
-            best_reward = test_result["rews"].mean()
-            best_reward_std = test_result['rews'].std()
+                                   episode_per_test, logger, env_step, reward_metric)
+        if best_epoch == -1 or best_reward < test_result["rew"]:
+            best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
             best_epoch = epoch
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(f"Epoch #{epoch}: test_reward: {test_result['rews'].mean():.6f} ± "
-                  f"{test_result['rews'].std():.6f}, best_reward: {best_reward:.6f} ± "
+            print(f"Epoch #{epoch}: test_reward: {test_result['rew']:.6f} ± "
+                  f"{test_result['rew_std']:.6f}, best_reward: {best_reward:.6f} ± "
                   f"{best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -68,7 +68,7 @@ def offpolicy_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param BaseLogger logger: A logger that logs statistics during 
+    :param BaseLogger logger: A logger that logs statistics during
         training/testing/updating. Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
     :param bool test_in_train: whether to test in the training phase. Default to True.

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -70,7 +70,7 @@ def onpolicy_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param BaseLogger logger: A logger that logs statistics during 
+    :param BaseLogger logger: A logger that logs statistics during
         training/testing/updating. Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
     :param bool test_in_train: whether to test in the training phase. Default to True.

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -155,9 +155,8 @@ def onpolicy_trainer(
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(
-                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
-                f" {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
+            print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
+                  f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break
     return gather_info(start_time, train_collector, test_collector,

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -2,12 +2,11 @@ import time
 import tqdm
 import numpy as np
 from collections import defaultdict
-from torch.utils.tensorboard import SummaryWriter
 from typing import Dict, Union, Callable, Optional
 
 from tianshou.data import Collector
 from tianshou.policy import BasePolicy
-from tianshou.utils import tqdm_config, MovAvg
+from tianshou.utils import tqdm_config, MovAvg, BaseLogger, LazyLogger
 from tianshou.trainer import test_episode, gather_info
 
 
@@ -27,8 +26,7 @@ def onpolicy_trainer(
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-    writer: Optional[SummaryWriter] = None,
-    log_interval: int = 1,
+    logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
     test_in_train: bool = True,
 ) -> Dict[str, Union[float, str]]:
@@ -85,16 +83,16 @@ def onpolicy_trainer(
         Only either one of step_per_collect and episode_per_collect can be specified.
     """
     env_step, gradient_step = 0, 0
+    last_rew, last_len = 0.0, 0
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     train_collector.reset_stat()
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
     test_result = test_episode(policy, test_collector, test_fn, 0, episode_per_test,
-                               writer, env_step, reward_metric)
+                               logger, env_step, reward_metric)
     best_epoch = 0
-    best_reward = test_result["rews"].mean()
-    best_reward_std = test_result["rews"].std()
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
     for epoch in range(1, 1 + max_epoch):
         # train
         policy.train()
@@ -110,29 +108,27 @@ def onpolicy_trainer(
                     result["rews"] = reward_metric(result["rews"])
                 env_step += int(result["n/st"])
                 t.update(result["n/st"])
+                logger.log_train_data(result, env_step)
+                last_rew = result['rew'] if 'rew' in result else last_rew
+                last_len = result['len'] if 'len' in result else last_len
                 data = {
                     "env_step": str(env_step),
-                    "rew": f"{result['rews'].mean():.2f}",
-                    "len": str(int(result["lens"].mean())),
+                    "rew": f"{last_rew:.2f}",
+                    "len": str(last_len),
                     "n/ep": str(int(result["n/ep"])),
                     "n/st": str(int(result["n/st"])),
                 }
-                if writer and env_step % log_interval == 0:
-                    writer.add_scalar(
-                        "train/rew", result['rews'].mean(), global_step=env_step)
-                    writer.add_scalar(
-                        "train/len", result['lens'].mean(), global_step=env_step)
-                if test_in_train and stop_fn and stop_fn(result["rews"].mean()):
+                if test_in_train and stop_fn and stop_fn(result["rew"]):
                     test_result = test_episode(
                         policy, test_collector, test_fn,
-                        epoch, episode_per_test, writer, env_step)
-                    if stop_fn(test_result["rews"].mean()):
+                        epoch, episode_per_test, logger, env_step)
+                    if stop_fn(test_result["rew"]):
                         if save_fn:
                             save_fn(policy)
                         t.set_postfix(**data)
                         return gather_info(
                             start_time, train_collector, test_collector,
-                            test_result["rews"].mean(), test_result["rews"].std())
+                            test_result["rew"], test_result["rew_std"])
                     else:
                         policy.train()
                 losses = policy.update(
@@ -145,24 +141,23 @@ def onpolicy_trainer(
                 for k in losses.keys():
                     stat[k].add(losses[k])
                     data[k] = f"{stat[k].get():.6f}"
-                    if writer and gradient_step % log_interval == 0:
-                        writer.add_scalar(
-                            k, stat[k].get(), global_step=gradient_step)
+                for k in losses.keys():
+                    losses[k] = stat[k].get()
+                logger.log_update_data(losses, gradient_step)
                 t.set_postfix(**data)
             if t.n <= t.total:
                 t.update()
         # test
         test_result = test_episode(policy, test_collector, test_fn, epoch,
-                                   episode_per_test, writer, env_step)
-        if best_epoch == -1 or best_reward < test_result["rews"].mean():
-            best_reward = test_result["rews"].mean()
-            best_reward_std = test_result['rews'].std()
+                                   episode_per_test, logger, env_step)
+        if best_epoch == -1 or best_reward < test_result["rew"]:
+            best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
             best_epoch = epoch
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(f"Epoch #{epoch}: test_reward: {test_result['rews'].mean():.6f} ± "
-                  f"{test_result['rews'].std():.6f}, best_reward: {best_reward:.6f} ± "
+            print(f"Epoch #{epoch}: test_reward: {test_result['rew']:.6f} ± "
+                  f"{test_result['rew_std']:.6f}, best_reward: {best_reward:.6f} ± "
                   f"{best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -70,9 +70,8 @@ def onpolicy_trainer(
         result to monitor training in the multi-agent RL setting. This function
         specifies what is the desired metric, e.g., the reward of agent 1 or the
         average reward over all agents.
-    :param torch.utils.tensorboard.SummaryWriter writer: a TensorBoard SummaryWriter;
-        if None is given, it will not write logs to TensorBoard. Default to None.
-    :param int log_interval: the log interval of the writer. Default to 1.
+    :param BaseLogger logger: A logger that logs statistics during 
+        training/testing/updating. Default to a logger that doesn't log anything.
     :param bool verbose: whether to print the information. Default to True.
     :param bool test_in_train: whether to test in the training phase. Default to True.
 

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -139,9 +139,8 @@ def onpolicy_trainer(
                 gradient_step += step
                 for k in losses.keys():
                     stat[k].add(losses[k])
-                    data[k] = f"{stat[k].get():.6f}"
-                for k in losses.keys():
                     losses[k] = stat[k].get()
+                    data[k] = f"{losses[k]:.6f}"
                 logger.log_update_data(losses, gradient_step)
                 t.set_postfix(**data)
             if t.n <= t.total:
@@ -149,15 +148,16 @@ def onpolicy_trainer(
         # test
         test_result = test_episode(policy, test_collector, test_fn, epoch,
                                    episode_per_test, logger, env_step)
-        if best_epoch == -1 or best_reward < test_result["rew"]:
-            best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
+        rew, rew_std = test_result["rew"], test_result["rew_std"]
+        if best_epoch == -1 or best_reward < rew:
+            best_reward, best_reward_std = rew, rew_std
             best_epoch = epoch
             if save_fn:
                 save_fn(policy)
         if verbose:
-            print(f"Epoch #{epoch}: test_reward: {test_result['rew']:.6f} ± "
-                  f"{test_result['rew_std']:.6f}, best_reward: {best_reward:.6f} ± "
-                  f"{best_reward_std:.6f} in #{best_epoch}")
+            print(
+                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
+                f" {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
         if stop_fn and stop_fn(best_reward):
             break
     return gather_info(start_time, train_collector, test_collector,

--- a/tianshou/trainer/utils.py
+++ b/tianshou/trainer/utils.py
@@ -1,10 +1,10 @@
 import time
 import numpy as np
-from torch.utils.tensorboard import SummaryWriter
 from typing import Any, Dict, Union, Callable, Optional
 
 from tianshou.data import Collector
 from tianshou.policy import BasePolicy
+from tianshou.utils import BaseLogger
 
 
 def test_episode(
@@ -13,7 +13,7 @@ def test_episode(
     test_fn: Optional[Callable[[int, Optional[int]], None]],
     epoch: int,
     n_episode: int,
-    writer: Optional[SummaryWriter] = None,
+    logger: Optional[BaseLogger] = None,
     global_step: Optional[int] = None,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
 ) -> Dict[str, Any]:
@@ -26,12 +26,8 @@ def test_episode(
     result = collector.collect(n_episode=n_episode)
     if reward_metric:
         result["rews"] = reward_metric(result["rews"])
-    if writer is not None and global_step is not None:
-        rews, lens = result["rews"], result["lens"]
-        writer.add_scalar("test/rew", rews.mean(), global_step=global_step)
-        writer.add_scalar("test/rew_std", rews.std(), global_step=global_step)
-        writer.add_scalar("test/len", lens.mean(), global_step=global_step)
-        writer.add_scalar("test/len_std", lens.std(), global_step=global_step)
+    if logger:
+        logger.log_test_data(result, global_step)
     return result
 
 

--- a/tianshou/trainer/utils.py
+++ b/tianshou/trainer/utils.py
@@ -26,7 +26,7 @@ def test_episode(
     result = collector.collect(n_episode=n_episode)
     if reward_metric:
         result["rews"] = reward_metric(result["rews"])
-    if logger:
+    if logger and global_step is not None:
         logger.log_test_data(result, global_step)
     return result
 

--- a/tianshou/utils/__init__.py
+++ b/tianshou/utils/__init__.py
@@ -1,9 +1,13 @@
 from tianshou.utils.config import tqdm_config
 from tianshou.utils.moving_average import MovAvg
 from tianshou.utils.log_tools import SummaryWriter
+from tianshou.utils.log_tools import BasicLogger, LazyLogger, BaseLogger
 
 __all__ = [
     "MovAvg",
     "tqdm_config",
     "SummaryWriter",
+    "BaseLogger",
+    "BasicLogger",
+    "LazyLogger",
 ]

--- a/tianshou/utils/__init__.py
+++ b/tianshou/utils/__init__.py
@@ -1,12 +1,10 @@
 from tianshou.utils.config import tqdm_config
 from tianshou.utils.moving_average import MovAvg
-from tianshou.utils.log_tools import SummaryWriter
 from tianshou.utils.log_tools import BasicLogger, LazyLogger, BaseLogger
 
 __all__ = [
     "MovAvg",
     "tqdm_config",
-    "SummaryWriter",
     "BaseLogger",
     "BasicLogger",
     "LazyLogger",

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -1,6 +1,9 @@
 import threading
+from numbers import Number
+import numpy as np
 from torch.utils import tensorboard
-from typing import Any, Dict, Optional
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional, Union
 
 
 class SummaryWriter(tensorboard.SummaryWriter):
@@ -45,3 +48,122 @@ class SummaryWriter(tensorboard.SummaryWriter):
             if key not in SummaryWriter._instance.keys():
                 SummaryWriter._instance[key] = SummaryWriter(*args, **kwargs)
         return SummaryWriter._instance[key]
+
+class BaseLogger(ABC):
+    """The base class for any logger which is compatible with trainer."""
+    def __init__(self, writer):
+        super().__init__()
+        self.writer = writer
+
+    @abstractmethod
+    def write(self, key: str,
+              x: Union[Number, np.number, np.ndarray],
+              y: Union[Number, np.number, np.ndarray],
+              **kwargs: Any) -> None:
+        """Specifies how writer is used to log data.
+
+            :param key: namespace which the input data tuple belongs to.
+            :param x: stands for the ordinate of the input data tuple.
+            :param x: stands for the abscissa of the input data tuple.
+        """
+        pass
+
+    def log_train_data(self, collect_result: dict, step: int) -> None:
+        """Use writer to log statistics generated during training.
+
+            :param collect_result: a dict containing information of data collected
+                in training stage, e.g. returns of collect() method in collector.
+        """
+        pass
+
+    def log_update_data(self, update_result: dict, step: int) -> None:
+        """Use writer to log statistics generated during updating.
+
+            :param update_result: a dict containing information of data collected
+                in updating stage, e.g. returns of update() method in policy.
+        """
+        pass
+
+    def log_test_data(self, collect_result: dict, step: int) -> None:
+        """Use writer to log statistics generated during evaluating.
+
+            :param collect_result: a dict containing information of data collected
+                in evaluating stage, e.g. returns of collect() method in collector.
+        """
+        pass
+
+    def set_checkpoint(self, **kwargs: Any) -> None:
+        """Set up checkpoint during training by saving policy, rendering, etc."""
+        pass
+
+class BasicLogger(BaseLogger):
+    """A loggger that relies on tensorboard.SummaryWriter by default to visualise
+    and log statistics. You can also rewrite write() func to use your own writer."""
+    def __init__(self, writer,
+                 train_interval = 1, test_interval = 1, update_interval = 1000,
+                 save_path = None):  
+        super().__init__(writer)
+        self.n_trainlog = 0
+        self.n_testlog = 0
+        self.n_updatelog = 0
+        self.train_interval = train_interval
+        self.test_interval = test_interval
+        self.update_interval = update_interval
+        self.last_log_train_step = -1
+        self.last_log_test_step = -1
+        self.last_log_update_step = -1
+        self.save_path = save_path
+        
+    def write(self, key, x, y):
+        self.writer.add_scalar(key, y, global_step=x)
+
+    def log_train_data(self, collect_result, step):
+        if collect_result["n/ep"] > 0:
+            if 'rew' not in collect_result:
+                collect_result['rew'] = collect_result['rews'].mean()
+            if 'len' not in collect_result:
+                collect_result['len'] = collect_result['lens'].mean()
+            if step - self.last_log_train_step >= self.train_interval:
+                self.write("train/n/ep", step, collect_result["n/ep"])  
+                self.write("train/rew", step, collect_result["rew"])
+                self.write("train/len", step, collect_result["len"])
+                self.last_log_train_step = step
+                self.n_trainlog += 1
+
+    def log_test_data(self, collect_result, step):
+        assert(collect_result["n/ep"] > 0)
+        if 'rew' not in collect_result:
+            collect_result['rew'] = collect_result['rews'].mean()
+        if 'len' not in collect_result:
+            collect_result['len'] = collect_result['lens'].mean()
+        if 'rew_std' not in collect_result:
+            collect_result['rew_std'] = collect_result['rews'].std()
+        if 'len_std' not in collect_result:
+            collect_result['len_std'] = collect_result['lens'].std()
+        if step - self.last_log_test_step >= self.test_interval:
+            self.write("test/rew", step, collect_result["rew"])
+            self.write("test/len", step, collect_result["len"])
+            self.write("test/rew_std", step, collect_result["rew_std"])
+            self.write("test/len_std", step, collect_result["len_std"])
+            self.last_log_test_step = step
+        self.n_testlog += 1        
+
+    def log_update_data(self, update_result, step):
+        if step - self.last_log_update_step >= self.update_interval:
+            for k, v in update_result.items():
+                self.write(k, step, v)
+            self.last_log_update_step = step
+            self.n_updatelog += 1
+
+    def global_log(self, **kwargs):
+        if 'policy' in kwargs and self.save_path:
+            import torch
+            torch.save(kwargs['policy'].state_dict(), self.save_path)
+
+class LazyLogger(BasicLogger):
+    """A loggger that does nothing. Used as placeholder in trainer."""
+    def __init__(self):
+        super().__init__(None)
+
+    def write(self, key, x, y):
+        pass

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -1,178 +1,140 @@
-import threading
-from numbers import Number
 import numpy as np
-from torch.utils import tensorboard
+from numbers import Number
+from typing import Any, Union
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Union
-
-
-class SummaryWriter(tensorboard.SummaryWriter):
-    """A more convenient Summary Writer(`tensorboard.SummaryWriter`).
-
-    You can get the same instance of summary writer everywhere after you
-    created one.
-    ::
-
-        >>> writer1 = SummaryWriter.get_instance(
-                key="first", log_dir="log/test_sw/first")
-        >>> writer2 = SummaryWriter.get_instance()
-        >>> writer1 is writer2
-        True
-        >>> writer4 = SummaryWriter.get_instance(
-                key="second", log_dir="log/test_sw/second")
-        >>> writer5 = SummaryWriter.get_instance(key="second")
-        >>> writer1 is not writer4
-        True
-        >>> writer4 is writer5
-        True
-    """
-
-    _mutex_lock = threading.Lock()
-    _default_key: str
-    _instance: Optional[Dict[str, "SummaryWriter"]] = None
-
-    @classmethod
-    def get_instance(
-        cls,
-        key: Optional[str] = None,
-        *args: Any,
-        **kwargs: Any,
-    ) -> "SummaryWriter":
-        """Get instance of torch.utils.tensorboard.SummaryWriter by key."""
-        with SummaryWriter._mutex_lock:
-            if key is None:
-                key = SummaryWriter._default_key
-            if SummaryWriter._instance is None:
-                SummaryWriter._instance = {}
-                SummaryWriter._default_key = key
-            if key not in SummaryWriter._instance.keys():
-                SummaryWriter._instance[key] = SummaryWriter(*args, **kwargs)
-        return SummaryWriter._instance[key]
+from torch.utils.tensorboard import SummaryWriter
 
 
 class BaseLogger(ABC):
     """The base class for any logger which is compatible with trainer."""
+
     def __init__(self, writer: Any) -> None:
         super().__init__()
         self.writer = writer
 
     @abstractmethod
-    def write(self, key: str,
-              x: Union[Number, np.number, np.ndarray],
-              y: Union[Number, np.number, np.ndarray],
-              **kwargs: Any) -> None:
+    def write(
+        self,
+        key: str,
+        x: Union[Number, np.number, np.ndarray],
+        y: Union[Number, np.number, np.ndarray],
+        **kwargs: Any,
+    ) -> None:
         """Specifies how writer is used to log data.
 
-            :param key: namespace which the input data tuple belongs to.
-            :param x: stands for the ordinate of the input data tuple.
-            :param x: stands for the abscissa of the input data tuple.
+        :param key: namespace which the input data tuple belongs to.
+        :param x: stands for the ordinate of the input data tuple.
+        :param y: stands for the abscissa of the input data tuple.
         """
         pass
 
     def log_train_data(self, collect_result: dict, step: int) -> None:
         """Use writer to log statistics generated during training.
 
-            :param collect_result: a dict containing information of data collected
-                in training stage, e.g. returns of collect() method in collector.
+        :param collect_result: a dict containing information of data collected in
+            training stage, i.e., returns of collect() method in collector.
+        :param int step: TODO
         """
         pass
 
     def log_update_data(self, update_result: dict, step: int) -> None:
         """Use writer to log statistics generated during updating.
 
-            :param update_result: a dict containing information of data collected
-                in updating stage, e.g. returns of update() method in policy.
+        :param update_result: a dict containing information of data collected in
+            updating stage, i.e., returns of update() method in policy.
+        :param int step: TODO
         """
         pass
 
     def log_test_data(self, collect_result: dict, step: int) -> None:
         """Use writer to log statistics generated during evaluating.
 
-            :param collect_result: a dict containing information of data collected
-                in evaluating stage, e.g. returns of collect() method in collector.
+        :param collect_result: a dict containing information of data collected in
+            evaluating stage, e.g. returns of collect() method in collector.
+        :param int step: TODO
         """
-        pass
-
-    def set_checkpoint(self, **kwargs: Any) -> None:
-        """Set up checkpoint during training by saving policy, rendering, etc."""
         pass
 
 
 class BasicLogger(BaseLogger):
-    """A loggger that relies on tensorboard.SummaryWriter by default to visualise
-    and log statistics. You can also rewrite write() func to use your own writer."""
-    def __init__(self, writer: Any,
-                 train_interval=1, test_interval=1, update_interval=1000,
-                 save_path=None) -> None:
+    """A loggger that relies on tensorboard SummaryWriter by default to visualize \
+    and log statistics.
+
+    You can also rewrite write() func to use your own writer.
+
+    :param SummaryWriter writer: TODO
+    :param int train_interval: TODO
+    :param int test_interval: TODO
+    :param int update_interval: TODO
+    """
+
+    def __init__(
+        self,
+        writer: SummaryWriter,
+        train_interval: int = 1,
+        test_interval: int = 1,
+        update_interval: int = 1000,
+    ) -> None:
         super().__init__(writer)
-        self.n_trainlog = 0
-        self.n_testlog = 0
-        self.n_updatelog = 0
         self.train_interval = train_interval
         self.test_interval = test_interval
         self.update_interval = update_interval
         self.last_log_train_step = -1
         self.last_log_test_step = -1
         self.last_log_update_step = -1
-        self.save_path = save_path
 
-    def write(self, key: str,
-              x: Union[Number, np.number, np.ndarray],
-              y: Union[Number, np.number, np.ndarray],
-              **kwargs: Any) -> None:
+    def write(
+        self,
+        key: str,
+        x: Union[Number, np.number, np.ndarray],
+        y: Union[Number, np.number, np.ndarray],
+        **kwargs: Any,
+    ) -> None:
         self.writer.add_scalar(key, y, global_step=x)
 
     def log_train_data(self, collect_result: dict, step: int) -> None:
+        """TODO: mention it may inplace modify collect_result."""
         if collect_result["n/ep"] > 0:
-            if 'rew' not in collect_result:
-                collect_result['rew'] = collect_result['rews'].mean()
-            if 'len' not in collect_result:
-                collect_result['len'] = collect_result['lens'].mean()
+            collect_result["rew"] = collect_result["rews"].mean()
+            collect_result["len"] = collect_result["lens"].mean()
             if step - self.last_log_train_step >= self.train_interval:
                 self.write("train/n/ep", step, collect_result["n/ep"])
                 self.write("train/rew", step, collect_result["rew"])
                 self.write("train/len", step, collect_result["len"])
                 self.last_log_train_step = step
-                self.n_trainlog += 1
 
     def log_test_data(self, collect_result: dict, step: int) -> None:
-        assert(collect_result["n/ep"] > 0)
-        if 'rew' not in collect_result:
-            collect_result['rew'] = collect_result['rews'].mean()
-        if 'len' not in collect_result:
-            collect_result['len'] = collect_result['lens'].mean()
-        if 'rew_std' not in collect_result:
-            collect_result['rew_std'] = collect_result['rews'].std()
-        if 'len_std' not in collect_result:
-            collect_result['len_std'] = collect_result['lens'].std()
+        """TODO: mention it may inplace modify collect_result."""
+        assert collect_result["n/ep"] > 0
+        rews, lens = collect_result["rews"], collect_result["lens"]
+        rew, rew_std, len_, len_std = rews.mean(), rews.std(), lens.mean(), lens.std()
+        collect_result.update(rew=rew, rew_std=rew_std, len=len_, len_std=len_std)
         if step - self.last_log_test_step >= self.test_interval:
-            self.write("test/rew", step, collect_result["rew"])
-            self.write("test/len", step, collect_result["len"])
-            self.write("test/rew_std", step, collect_result["rew_std"])
-            self.write("test/len_std", step, collect_result["len_std"])
+            self.write("test/rew", step, rew)
+            self.write("test/len", step, len_)
+            self.write("test/rew_std", step, rew_std)
+            self.write("test/len_std", step, len_std)
             self.last_log_test_step = step
-        self.n_testlog += 1
 
     def log_update_data(self, update_result: dict, step: int) -> None:
         if step - self.last_log_update_step >= self.update_interval:
             for k, v in update_result.items():
-                self.write(k, step, v)
+                self.write("train/" + k, step, v)  # save in train/
             self.last_log_update_step = step
-            self.n_updatelog += 1
-
-    def global_log(self, **kwargs: Any) -> None:
-        if 'policy' in kwargs and self.save_path:
-            import torch
-            torch.save(kwargs['policy'].state_dict(), self.save_path)
 
 
 class LazyLogger(BasicLogger):
-    """A loggger that does nothing. Used as placeholder in trainer."""
-    def __init__(self) -> None:
-        super().__init__(None)
+    """A loggger that does nothing. Used as the placeholder in trainer."""
 
-    def write(self, key: str,
-              x: Union[Number, np.number, np.ndarray],
-              y: Union[Number, np.number, np.ndarray],
-              **kwargs: Any) -> None:
+    def __init__(self) -> None:
+        super().__init__(None)  # type: ignore
+
+    def write(
+        self,
+        key: str,
+        x: Union[Number, np.number, np.ndarray],
+        y: Union[Number, np.number, np.ndarray],
+        **kwargs: Any,
+    ) -> None:
+        """The LazyLogger writes nothing."""
         pass

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -49,6 +49,7 @@ class SummaryWriter(tensorboard.SummaryWriter):
                 SummaryWriter._instance[key] = SummaryWriter(*args, **kwargs)
         return SummaryWriter._instance[key]
 
+
 class BaseLogger(ABC):
     """The base class for any logger which is compatible with trainer."""
     def __init__(self, writer):
@@ -96,12 +97,13 @@ class BaseLogger(ABC):
         """Set up checkpoint during training by saving policy, rendering, etc."""
         pass
 
+
 class BasicLogger(BaseLogger):
     """A loggger that relies on tensorboard.SummaryWriter by default to visualise
     and log statistics. You can also rewrite write() func to use your own writer."""
     def __init__(self, writer,
                  train_interval=1, test_interval=1, update_interval=1000,
-                 save_path=None):  
+                 save_path=None):
         super().__init__(writer)
         self.n_trainlog = 0
         self.n_testlog = 0
@@ -146,7 +148,7 @@ class BasicLogger(BaseLogger):
             self.write("test/rew_std", step, collect_result["rew_std"])
             self.write("test/len_std", step, collect_result["len_std"])
             self.last_log_test_step = step
-        self.n_testlog += 1        
+        self.n_testlog += 1
 
     def log_update_data(self, update_result, step):
         if step - self.last_log_update_step >= self.update_interval:
@@ -159,6 +161,7 @@ class BasicLogger(BaseLogger):
         if 'policy' in kwargs and self.save_path:
             import torch
             torch.save(kwargs['policy'].state_dict(), self.save_path)
+
 
 class LazyLogger(BasicLogger):
     """A loggger that does nothing. Used as placeholder in trainer."""

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -52,7 +52,7 @@ class SummaryWriter(tensorboard.SummaryWriter):
 
 class BaseLogger(ABC):
     """The base class for any logger which is compatible with trainer."""
-    def __init__(self, writer):
+    def __init__(self, writer: Any) -> None:
         super().__init__()
         self.writer = writer
 
@@ -101,9 +101,9 @@ class BaseLogger(ABC):
 class BasicLogger(BaseLogger):
     """A loggger that relies on tensorboard.SummaryWriter by default to visualise
     and log statistics. You can also rewrite write() func to use your own writer."""
-    def __init__(self, writer,
+    def __init__(self, writer: Any,
                  train_interval=1, test_interval=1, update_interval=1000,
-                 save_path=None):
+                 save_path=None) -> None:
         super().__init__(writer)
         self.n_trainlog = 0
         self.n_testlog = 0
@@ -116,10 +116,13 @@ class BasicLogger(BaseLogger):
         self.last_log_update_step = -1
         self.save_path = save_path
 
-    def write(self, key, x, y):
+    def write(self, key: str,
+              x: Union[Number, np.number, np.ndarray],
+              y: Union[Number, np.number, np.ndarray],
+              **kwargs: Any) -> None:
         self.writer.add_scalar(key, y, global_step=x)
 
-    def log_train_data(self, collect_result, step):
+    def log_train_data(self, collect_result: dict, step: int) -> None:
         if collect_result["n/ep"] > 0:
             if 'rew' not in collect_result:
                 collect_result['rew'] = collect_result['rews'].mean()
@@ -132,7 +135,7 @@ class BasicLogger(BaseLogger):
                 self.last_log_train_step = step
                 self.n_trainlog += 1
 
-    def log_test_data(self, collect_result, step):
+    def log_test_data(self, collect_result: dict, step: int) -> None:
         assert(collect_result["n/ep"] > 0)
         if 'rew' not in collect_result:
             collect_result['rew'] = collect_result['rews'].mean()
@@ -150,14 +153,14 @@ class BasicLogger(BaseLogger):
             self.last_log_test_step = step
         self.n_testlog += 1
 
-    def log_update_data(self, update_result, step):
+    def log_update_data(self, update_result: dict, step: int) -> None:
         if step - self.last_log_update_step >= self.update_interval:
             for k, v in update_result.items():
                 self.write(k, step, v)
             self.last_log_update_step = step
             self.n_updatelog += 1
 
-    def global_log(self, **kwargs):
+    def global_log(self, **kwargs: Any) -> None:
         if 'policy' in kwargs and self.save_path:
             import torch
             torch.save(kwargs['policy'].state_dict(), self.save_path)
@@ -165,8 +168,11 @@ class BasicLogger(BaseLogger):
 
 class LazyLogger(BasicLogger):
     """A loggger that does nothing. Used as placeholder in trainer."""
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(None)
 
-    def write(self, key, x, y):
+    def write(self, key: str,
+              x: Union[Number, np.number, np.ndarray],
+              y: Union[Number, np.number, np.ndarray],
+              **kwargs: Any) -> None:
         pass

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -20,7 +20,7 @@ class BaseLogger(ABC):
         y: Union[Number, np.number, np.ndarray],
         **kwargs: Any,
     ) -> None:
-        """Specifies how writer is used to log data.
+        """Specify how the writer is used to log data.
 
         :param key: namespace which the input data tuple belongs to.
         :param x: stands for the ordinate of the input data tuple.
@@ -32,8 +32,8 @@ class BaseLogger(ABC):
         """Use writer to log statistics generated during training.
 
         :param collect_result: a dict containing information of data collected in
-            training stage, i.e., returns of collect() method in collector.
-        :param int step: TODO
+            training stage, i.e., returns of collector.collect().
+        :param int step: stands for the timestep the collect_result being logged.
         """
         pass
 
@@ -41,8 +41,8 @@ class BaseLogger(ABC):
         """Use writer to log statistics generated during updating.
 
         :param update_result: a dict containing information of data collected in
-            updating stage, i.e., returns of update() method in policy.
-        :param int step: TODO
+            updating stage, i.e., returns of policy.update().
+        :param int step: stands for the timestep the collect_result being logged.
         """
         pass
 
@@ -50,8 +50,8 @@ class BaseLogger(ABC):
         """Use writer to log statistics generated during evaluating.
 
         :param collect_result: a dict containing information of data collected in
-            evaluating stage, e.g. returns of collect() method in collector.
-        :param int step: TODO
+            evaluating stage, i.e., returns of collector.collect().
+        :param int step: stands for the timestep the collect_result being logged.
         """
         pass
 
@@ -62,10 +62,10 @@ class BasicLogger(BaseLogger):
 
     You can also rewrite write() func to use your own writer.
 
-    :param SummaryWriter writer: TODO
-    :param int train_interval: TODO
-    :param int test_interval: TODO
-    :param int update_interval: TODO
+    :param SummaryWriter writer: the writer to log data.
+    :param int train_interval: the log interval in log_train_data(). Default to 1.
+    :param int test_interval: the log interval in log_test_data(). Default to 1.
+    :param int update_interval: the log interval in log_update_data(). Default to 1000.
     """
 
     def __init__(
@@ -93,7 +93,16 @@ class BasicLogger(BaseLogger):
         self.writer.add_scalar(key, y, global_step=x)
 
     def log_train_data(self, collect_result: dict, step: int) -> None:
-        """TODO: mention it may inplace modify collect_result."""
+        """Use writer to log statistics generated during training.
+
+        :param collect_result: a dict containing information of data collected in
+            training stage, i.e., returns of collector.collect().
+        :param int step: stands for the timestep the collect_result being logged.
+
+        .. note::
+
+            ``collect_result`` will be modified in-place with "rew" and "len" keys.
+        """
         if collect_result["n/ep"] > 0:
             collect_result["rew"] = collect_result["rews"].mean()
             collect_result["len"] = collect_result["lens"].mean()
@@ -104,7 +113,17 @@ class BasicLogger(BaseLogger):
                 self.last_log_train_step = step
 
     def log_test_data(self, collect_result: dict, step: int) -> None:
-        """TODO: mention it may inplace modify collect_result."""
+        """Use writer to log statistics generated during evaluating.
+
+        :param collect_result: a dict containing information of data collected in
+            evaluating stage, i.e., returns of collector.collect().
+        :param int step: stands for the timestep the collect_result being logged.
+
+        .. note::
+
+            ``collect_result`` will be modified in-place with "rew", "rew_std", "len",
+            and "len_std" keys.
+        """
         assert collect_result["n/ep"] > 0
         rews, lens = collect_result["rews"], collect_result["lens"]
         rew, rew_std, len_, len_std = rews.mean(), rews.std(), lens.mean(), lens.std()

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -100,8 +100,8 @@ class BasicLogger(BaseLogger):
     """A loggger that relies on tensorboard.SummaryWriter by default to visualise
     and log statistics. You can also rewrite write() func to use your own writer."""
     def __init__(self, writer,
-                 train_interval = 1, test_interval = 1, update_interval = 1000,
-                 save_path = None):  
+                 train_interval=1, test_interval=1, update_interval=1000,
+                 save_path=None):  
         super().__init__(writer)
         self.n_trainlog = 0
         self.n_testlog = 0
@@ -113,7 +113,7 @@ class BasicLogger(BaseLogger):
         self.last_log_test_step = -1
         self.last_log_update_step = -1
         self.save_path = save_path
-        
+
     def write(self, key, x, y):
         self.writer.add_scalar(key, y, global_step=x)
 
@@ -124,7 +124,7 @@ class BasicLogger(BaseLogger):
             if 'len' not in collect_result:
                 collect_result['len'] = collect_result['lens'].mean()
             if step - self.last_log_train_step >= self.train_interval:
-                self.write("train/n/ep", step, collect_result["n/ep"])  
+                self.write("train/n/ep", step, collect_result["n/ep"])
                 self.write("train/rew", step, collect_result["rew"])
                 self.write("train/len", step, collect_result["len"])
                 self.last_log_train_step = step


### PR DESCRIPTION
This is the 4th commit of 6 commits mentioned in #274, which features refactor of trainer to fix #161. You can check #274 for more detail.
To avoid large commit as in #280, I will do this in 2 pr. first(#293 ) focus on some definition change of trainer to make it more friendly to use and be consistent with typical usage in research papers. Second pr focus on refactor of logging method to solve bug of nan reward and log interval. After these two pr, hopefully fundamental change of tianshou/data is finished. We then can concentrate on building benchmarks of tianshou finally.
This is the second pr.

This pr also fixes the bug that 'rew' is nan in tqdm visualization.

Not finished yet, lacking test and docs update. Open to discussion
