### PR TITLE
Add lr_scheduler option for Onpolicy algorithm

### DIFF
--- a/tianshou/policy/modelfree/a2c.py
+++ b/tianshou/policy/modelfree/a2c.py
@@ -142,8 +142,10 @@ class A2CPolicy(PGPolicy):
                 vf_losses.append(vf_loss.item())
                 ent_losses.append(ent_loss.item())
                 losses.append(loss.item())
+        # update learning rate if given lr_scheduler
+        if self.lr_scheduler is not None:
+            self.lr_scheduler.step()
 
-        self.update_lr_scheduler()
         return {
             "loss": losses,
             "loss/actor": actor_losses,

--- a/tianshou/policy/modelfree/a2c.py
+++ b/tianshou/policy/modelfree/a2c.py
@@ -142,6 +142,8 @@ class A2CPolicy(PGPolicy):
                 vf_losses.append(vf_loss.item())
                 ent_losses.append(ent_loss.item())
                 losses.append(loss.item())
+
+        self.update_lr_scheduler()
         return {
             "loss": losses,
             "loss/actor": actor_losses,

--- a/tianshou/policy/modelfree/a2c.py
+++ b/tianshou/policy/modelfree/a2c.py
@@ -38,6 +38,8 @@ class A2CPolicy(PGPolicy):
         squashing) for now, or empty string for no bounding. Default to "clip".
     :param Optional[gym.Space] action_space: env's action space, mandatory if you want
         to use option "action_scaling" or "action_bound_method". Default to None.
+    :param lr_scheduler: a learning rate scheduler that adjusts the learning rate in
+        optimizer in each policy.update(). Default to None (no lr_scheduler).
 
     .. seealso::
 
@@ -142,7 +144,7 @@ class A2CPolicy(PGPolicy):
                 vf_losses.append(vf_loss.item())
                 ent_losses.append(ent_loss.item())
                 losses.append(loss.item())
-        # update learning rate if given lr_scheduler
+        # update learning rate if lr_scheduler is given
         if self.lr_scheduler is not None:
             self.lr_scheduler.step()
 

--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -32,6 +32,7 @@ class PGPolicy(BasePolicy):
     def __init__(
         self,
         model: Optional[torch.nn.Module],
+        #TODO lack doc
         optim: torch.optim.Optimizer,
         dist_fn: Type[torch.distributions.Distribution],
         discount_factor: float = 0.99,
@@ -110,7 +111,13 @@ class PGPolicy(BasePolicy):
                 loss.backward()
                 self.optim.step()
                 losses.append(loss.item())
+        
+        self.update_lr_scheduler()
         return {"loss": losses}
+
+    def update_lr_scheduler(self):
+        if hasattr(self.optim, "lr_scheduler"):
+            self.optim.lr_scheduler.step()
 
     # def _vanilla_returns(self, batch):
     #     returns = batch.rew[:]

--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -22,6 +22,8 @@ class PGPolicy(BasePolicy):
         squashing) for now, or empty string for no bounding. Default to "clip".
     :param Optional[gym.Space] action_space: env's action space, mandatory if you want
         to use option "action_scaling" or "action_bound_method". Default to None.
+    :param lr_scheduler: a learning rate scheduler that adjusts the learning rate in
+        optimizer in each policy.update(). Default to None (no lr_scheduler).
 
     .. seealso::
 
@@ -32,15 +34,13 @@ class PGPolicy(BasePolicy):
     def __init__(
         self,
         model: Optional[torch.nn.Module],
-        #TODO lack doc
         optim: torch.optim.Optimizer,
         dist_fn: Type[torch.distributions.Distribution],
         discount_factor: float = 0.99,
         reward_normalization: bool = False,
         action_scaling: bool = True,
         action_bound_method: str = "clip",
-        # TODO doc
-        lr_scheduler: Optional[torch.optim.lr_scheduler] = None,
+        lr_scheduler: Optional[torch.optim.lr_scheduler.LambdaLR] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(action_scaling=action_scaling,
@@ -114,12 +114,11 @@ class PGPolicy(BasePolicy):
                 loss.backward()
                 self.optim.step()
                 losses.append(loss.item())
-        # update learning rate if given lr_scheduler
+        # update learning rate if lr_scheduler is given
         if self.lr_scheduler is not None:
             self.lr_scheduler.step()
 
         return {"loss": losses}
-
 
     # def _vanilla_returns(self, batch):
     #     returns = batch.rew[:]

--- a/tianshou/policy/modelfree/ppo.py
+++ b/tianshou/policy/modelfree/ppo.py
@@ -179,6 +179,8 @@ class PPOPolicy(PGPolicy):
                         list(self.actor.parameters()) + list(self.critic.parameters()),
                         self._max_grad_norm)
                 self.optim.step()
+
+        self.update_lr_scheduler()
         return {
             "loss": losses,
             "loss/clip": clip_losses,

--- a/tianshou/policy/modelfree/ppo.py
+++ b/tianshou/policy/modelfree/ppo.py
@@ -43,6 +43,8 @@ class PPOPolicy(PGPolicy):
         squashing) for now, or empty string for no bounding. Default to "clip".
     :param Optional[gym.Space] action_space: env's action space, mandatory if you want
         to use option "action_scaling" or "action_bound_method". Default to None.
+    :param lr_scheduler: a learning rate scheduler that adjusts the learning rate in
+        optimizer in each policy.update(). Default to None (no lr_scheduler).
 
     .. seealso::
 
@@ -179,7 +181,7 @@ class PPOPolicy(PGPolicy):
                         list(self.actor.parameters()) + list(self.critic.parameters()),
                         self._max_grad_norm)
                 self.optim.step()
-        # update learning rate if given lr_scheduler
+        # update learning rate if lr_scheduler is given
         if self.lr_scheduler is not None:
             self.lr_scheduler.step()
 

--- a/tianshou/policy/modelfree/ppo.py
+++ b/tianshou/policy/modelfree/ppo.py
@@ -179,8 +179,10 @@ class PPOPolicy(PGPolicy):
                         list(self.actor.parameters()) + list(self.critic.parameters()),
                         self._max_grad_norm)
                 self.optim.step()
+        # update learning rate if given lr_scheduler
+        if self.lr_scheduler is not None:
+            self.lr_scheduler.step()
 
-        self.update_lr_scheduler()
         return {
             "loss": losses,
             "loss/clip": clip_losses,


### PR DESCRIPTION
linear lr decay is important for both PPO and REINFORCEMENT benchmark as in #307, You can do something like below to change lr as you like when training.  My solution is quite and easy forwarded.

```
from torch.optim.lr_scheduler import LambdaLR
import torch.nn as nn
import torch
from torch.optim import *


class net(nn.Module):
    def __init__(self):
        super(net,self).__init__()
        self.fc = nn.Linear(1,10)
    def forward(self,x):
        return self.fc(x)
model = net()

optimizer = Adam(model.parameters(),lr = 0.01)
max_update_num=10
lambda1 = lambda epoch: (1 - epoch/max_update_num)
optimizer.scheduler = lr_scheduler.LambdaLR(optimizer,lr_lambda = lambda1)
```
Then pass in the optimizer and policy will change lr every update automatically.

This way you get to not adding new APIs.
