### PR TITLE
Make trainer resumable

### DIFF
--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -41,6 +41,7 @@ To resume training process from an existing checkpoint, you need to do the follo
 
 1. Make sure you write ``save_checkpoint_fn`` which saves everything needed in the training process, i.e., policy, optim, buffer; pass it to trainer;
 2. Use ``BasicLogger`` which contains a tensorboard;
+3. To adjust the save frequency, specify ``save_interval`` when initializing BasicLogger.
 
 And to successfully resume from a checkpoint:
 

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -47,7 +47,7 @@ And to successfully resume from a checkpoint:
 1. Load everything needed in the training process **before trainer initialization**, i.e., policy, optim, buffer;
 2. set ``resume_from_log=True`` with trainer;
 
-We provide an example to show how these steps work: checkout `test_c51.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_c51.py>`_ by running
+We provide an example to show how these steps work: checkout `test_c51.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_c51.py>`_ or `test_ppo.py <https://github.com/thu-ml/tianshou/blob/master/test/continuous/test_ppo.py>`_ by running
 
 .. code-block:: bash
 

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -30,6 +30,31 @@ Customize Training Process
 See :ref:`customized_trainer`.
 
 
+.. _resume_training:
+
+Resume Training Process
+-----------------------
+
+This is related to `Issue 349 <https://github.com/thu-ml/tianshou/issues/349>`_.
+
+To resume training process from an existing checkpoint, you need to do the following things in the training process:
+
+1. Make sure you write ``save_train_fn`` which saves everything needed in the training process, i.e., policy, optim, buffer; pass it to trainer;
+2. Use ``BasicLogger`` which contains a tensorboard;
+
+And to successfully resume from a checkpoint:
+
+1. Load everything needed in the training process **before trainer initialization**, i.e., policy, optim, buffer;
+2. set ``resume_from_log=True`` with trainer;
+
+We provide an example to show how these steps work: checkout `test_c51.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_c51.py>`_ by running
+
+.. code-block:: bash
+
+    $ python3 test/discrete/test_c51.py  # train some epoch
+    $ python3 test/discrete/test_c51.py --resume  # restore from existing log and continuing training
+
+
 .. _parallel_sampling:
 
 Parallel Sampling

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -45,11 +45,11 @@ To resume training process from an existing checkpoint, you need to do the follo
 And to successfully resume from a checkpoint:
 
 1. Load everything needed in the training process **before trainer initialization**, i.e., policy, optim, buffer;
-2. set ``resume_from_log=True`` with trainer;
+2. Set ``resume_from_log=True`` with trainer;
 
-We provide an example to show how these steps work: checkout `test_c51.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_c51.py>`_ or `test_ppo.py <https://github.com/thu-ml/tianshou/blob/master/test/continuous/test_ppo.py>`_ by running
+We provide an example to show how these steps work: checkout `test_c51.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_c51.py>`_, `test_ppo.py <https://github.com/thu-ml/tianshou/blob/master/test/continuous/test_ppo.py>`_ or `test_il_bcq.py <https://github.com/thu-ml/tianshou/blob/master/test/discrete/test_il_bcq.py>`_ by running
 
-.. code-block:: bash
+.. code-block:: console
 
     $ python3 test/discrete/test_c51.py  # train some epoch
     $ python3 test/discrete/test_c51.py --resume  # restore from existing log and continuing training

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -56,7 +56,7 @@ We provide an example to show how these steps work: checkout `test_c51.py <https
     $ python3 test/discrete/test_c51.py --resume  # restore from existing log and continuing training
 
 
-To correctly render the data (including several tfevent files), we highly recommend using ``tensorboard >= 2.5.0``.
+To correctly render the data (including several tfevent files), we highly recommend using ``tensorboard >= 2.5.0`` (see `here <https://github.com/thu-ml/tianshou/pull/350#issuecomment-829123378>`_ for the reason). Otherwise, it may cause overlapping issue that you need to manually handle with.
 
 .. _parallel_sampling:
 

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -39,7 +39,7 @@ This is related to `Issue 349 <https://github.com/thu-ml/tianshou/issues/349>`_.
 
 To resume training process from an existing checkpoint, you need to do the following things in the training process:
 
-1. Make sure you write ``save_train_fn`` which saves everything needed in the training process, i.e., policy, optim, buffer; pass it to trainer;
+1. Make sure you write ``save_checkpoint_fn`` which saves everything needed in the training process, i.e., policy, optim, buffer; pass it to trainer;
 2. Use ``BasicLogger`` which contains a tensorboard;
 
 And to successfully resume from a checkpoint:

--- a/docs/tutorials/cheatsheet.rst
+++ b/docs/tutorials/cheatsheet.rst
@@ -56,6 +56,8 @@ We provide an example to show how these steps work: checkout `test_c51.py <https
     $ python3 test/discrete/test_c51.py --resume  # restore from existing log and continuing training
 
 
+To correctly render the data (including several tfevent files), we highly recommend using ``tensorboard >= 2.5.0``.
+
 .. _parallel_sampling:
 
 Parallel Sampling

--- a/examples/atari/atari_bcq.py
+++ b/examples/atari/atari_bcq.py
@@ -85,8 +85,7 @@ def test_discrete_bcq(args=get_args()):
         feature_net, args.action_shape, device=args.device,
         hidden_sizes=args.hidden_sizes, softmax_output=False).to(args.device)
     optim = torch.optim.Adam(
-        set(policy_net.parameters()).union(imitation_net.parameters()),
-        lr=args.lr)
+        list(policy_net.parameters()) + list(imitation_net.parameters()), lr=args.lr)
     # define policy
     policy = DiscreteBCQPolicy(
         policy_net, imitation_net, optim, args.gamma, args.n_step,

--- a/examples/mujoco/mujoco_a2c.py
+++ b/examples/mujoco/mujoco_a2c.py
@@ -101,7 +101,7 @@ def test_a2c(args=get_args()):
             torch.nn.init.zeros_(m.bias)
             m.weight.data.copy_(0.01 * m.weight.data)
 
-    optim = torch.optim.RMSprop(set(actor.parameters()).union(critic.parameters()),
+    optim = torch.optim.RMSprop(list(actor.parameters()) + list(critic.parameters()),
                                 lr=args.lr, eps=1e-5, alpha=0.99)
 
     lr_scheduler = None

--- a/examples/mujoco/mujoco_ppo.py
+++ b/examples/mujoco/mujoco_ppo.py
@@ -106,8 +106,8 @@ def test_ppo(args=get_args()):
             torch.nn.init.zeros_(m.bias)
             m.weight.data.copy_(0.01 * m.weight.data)
 
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
 
     lr_scheduler = None
     if args.lr_decay:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "gym>=0.15.4",
         "tqdm",
         "numpy>1.16.0",  # https://github.com/numpy/numpy/issues/12793
-        "tensorboard",
+        "tensorboard>=2.5.0",
         "torch>=1.4.0",
         "numba>=0.51.0",
         "h5py>=2.10.0",  # to match tensorflow's minimal requirements

--- a/test/continuous/test_ddpg.py
+++ b/test/continuous/test_ddpg.py
@@ -105,6 +105,7 @@ def test_ddpg(args=get_args()):
         update_per_step=args.update_per_step, stop_fn=stop_fn,
         save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/continuous/test_npg.py
+++ b/test/continuous/test_npg.py
@@ -80,8 +80,8 @@ def test_npg(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
 
     # replace DiagGuassian with Independent(Normal) which is equivalent
     # pass *logits to be consistent with policy.forward

--- a/test/continuous/test_npg.py
+++ b/test/continuous/test_npg.py
@@ -80,8 +80,7 @@ def test_npg(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(
-        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(critic.parameters(), lr=args.lr)
 
     # replace DiagGuassian with Independent(Normal) which is equivalent
     # pass *logits to be consistent with policy.forward

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -48,6 +48,7 @@ def get_args():
     parser.add_argument('--norm-adv', type=int, default=1)
     parser.add_argument('--recompute-adv', type=int, default=0)
     parser.add_argument('--resume', action="store_true")
+    parser.add_argument("--save-interval", type=int, default=4)
     args = parser.parse_known_args()[0]
     return args
 
@@ -115,7 +116,7 @@ def test_ppo(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'ppo')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    logger = BasicLogger(writer, save_interval=args.save_interval)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -84,8 +84,8 @@ def test_ppo(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
 
     # replace DiagGuassian with Independent(Normal) which is equivalent
     # pass *logits to be consistent with policy.forward
@@ -137,7 +137,7 @@ def test_ppo(args=get_args()):
         if os.path.exists(ckpt_path):
             checkpoint = torch.load(ckpt_path, map_location=args.device)
             policy.load_state_dict(checkpoint['model'])
-            policy.optim.load_state_dict(checkpoint['optim'])
+            optim.load_state_dict(checkpoint['optim'])
             print("Successfully restore policy and optim.")
         else:
             print("Fail to restore policy and optim.")

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -127,7 +127,7 @@ def test_ppo(args=get_args()):
         # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
         torch.save({
             'model': policy.state_dict(),
-            'optim': policy.optim.state_dict(),
+            'optim': optim.state_dict(),
         }, os.path.join(log_path, 'checkpoint.pth'))
 
     if args.resume:

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -123,7 +123,7 @@ def test_ppo(args=get_args()):
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
 
-    def save_train_fn(epoch, env_step, gradient_step):
+    def save_checkpoint_fn(epoch, env_step, gradient_step):
         # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
         torch.save({
             'model': policy.state_dict(),
@@ -144,10 +144,11 @@ def test_ppo(args=get_args()):
 
     # trainer
     result = onpolicy_trainer(
-        policy, train_collector, test_collector, args.epoch,
-        args.step_per_epoch, args.repeat_per_collect, args.test_num, args.batch_size,
+        policy, train_collector, test_collector, args.epoch, args.step_per_epoch,
+        args.repeat_per_collect, args.test_num, args.batch_size,
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
-        logger=logger, resume_from_log=args.resume, save_train_fn=save_train_fn)
+        logger=logger, resume_from_log=args.resume,
+        save_checkpoint_fn=save_checkpoint_fn)
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -124,6 +124,7 @@ def test_sac_with_il(args=get_args()):
         update_per_step=args.update_per_step, stop_fn=stop_fn,
         save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/continuous/test_td3.py
+++ b/test/continuous/test_td3.py
@@ -119,6 +119,7 @@ def test_td3(args=get_args()):
         update_per_step=args.update_per_step, stop_fn=stop_fn,
         save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/continuous/test_trpo.py
+++ b/test/continuous/test_trpo.py
@@ -82,8 +82,8 @@ def test_trpo(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
 
     # replace DiagGuassian with Independent(Normal) which is equivalent
     # pass *logits to be consistent with policy.forward

--- a/test/continuous/test_trpo.py
+++ b/test/continuous/test_trpo.py
@@ -27,7 +27,8 @@ def get_args():
     parser.add_argument('--epoch', type=int, default=5)
     parser.add_argument('--step-per-epoch', type=int, default=50000)
     parser.add_argument('--step-per-collect', type=int, default=2048)
-    parser.add_argument('--repeat-per-collect', type=int, default=1)
+    parser.add_argument('--repeat-per-collect', type=int,
+                        default=2)  # theoretically it should be 1
     parser.add_argument('--batch-size', type=int, default=99999)
     parser.add_argument('--hidden-sizes', type=int, nargs='*', default=[64, 64])
     parser.add_argument('--training-num', type=int, default=16)
@@ -82,8 +83,7 @@ def test_trpo(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(
-        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(critic.parameters(), lr=args.lr)
 
     # replace DiagGuassian with Independent(Normal) which is equivalent
     # pass *logits to be consistent with policy.forward

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -74,8 +74,8 @@ def test_a2c_with_il(args=get_args()):
               device=args.device)
     actor = Actor(net, args.action_shape, device=args.device).to(args.device)
     critic = Critic(net, device=args.device).to(args.device)
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
     dist = torch.distributions.Categorical
     policy = A2CPolicy(
         actor, critic, optim, dist,
@@ -106,6 +106,7 @@ def test_a2c_with_il(args=get_args()):
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
         logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!
@@ -135,6 +136,7 @@ def test_a2c_with_il(args=get_args()):
         args.il_step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -48,6 +48,7 @@ def get_args():
     parser.add_argument(
         '--device', type=str,
         default='cuda' if torch.cuda.is_available() else 'cpu')
+    parser.add_argument("--save-interval", type=int, default=4)
     args = parser.parse_known_args()[0]
     return args
 
@@ -92,7 +93,7 @@ def test_c51(args=get_args()):
     # log
     log_path = os.path.join(args.logdir, args.task, 'c51')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    logger = BasicLogger(writer, save_interval=args.save_interval)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -1,6 +1,7 @@
 import os
 import gym
 import torch
+import pickle
 import pprint
 import argparse
 import numpy as np
@@ -43,6 +44,7 @@ def get_args():
                         action="store_true", default=False)
     parser.add_argument('--alpha', type=float, default=0.6)
     parser.add_argument('--beta', type=float, default=0.4)
+    parser.add_argument('--resume', action="store_true")
     parser.add_argument(
         '--device', type=str,
         default='cuda' if torch.cuda.is_available() else 'cpu')
@@ -112,14 +114,44 @@ def test_c51(args=get_args()):
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)
 
+    def save_train_fn(epoch, env_step, gradient_step):
+        # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
+        torch.save({
+            'model': policy.state_dict(),
+            'optim': policy.optim.state_dict(),
+        }, os.path.join(log_path, 'checkpoint.pth'))
+        pickle.dump(train_collector.buffer,
+                    open(os.path.join(log_path, 'train_buffer.pkl'), "wb"))
+
+    if args.resume:
+        # load from existing checkpoint
+        print(f"Loading agent under {log_path}")
+        ckpt_path = os.path.join(log_path, 'checkpoint.pth')
+        if os.path.exists(ckpt_path):
+            checkpoint = torch.load(ckpt_path, map_location=args.device)
+            policy.load_state_dict(checkpoint['model'])
+            policy.optim.load_state_dict(checkpoint['optim'])
+            print("Successfully restore policy and optim.")
+        else:
+            print("Fail to restore policy and optim.")
+        buffer_path = os.path.join(log_path, 'train_buffer.pkl')
+        if os.path.exists(buffer_path):
+            buffer = pickle.load(open(buffer_path, "rb"))
+            train_collector._assign_buffer(buffer)
+            print("Successfully restore buffer.")
+        else:
+            print("Fail to restore buffer.")
+
     # trainer
     result = offpolicy_trainer(
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
-        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
+        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
+        resume_from_log=args.resume, save_train_fn=save_train_fn)
 
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!
@@ -130,6 +162,11 @@ def test_c51(args=get_args()):
         result = collector.collect(n_episode=1, render=args.render)
         rews, lens = result["rews"], result["lens"]
         print(f"Final reward: {rews.mean()}, length: {lens.mean()}")
+
+
+def test_c51_resume(args=get_args()):
+    args.resume = True
+    test_c51(args)
 
 
 def test_pc51(args=get_args()):

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -114,7 +114,7 @@ def test_c51(args=get_args()):
     def test_fn(epoch, env_step):
         policy.set_eps(args.eps_test)
 
-    def save_train_fn(epoch, env_step, gradient_step):
+    def save_checkpoint_fn(epoch, env_step, gradient_step):
         # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
         torch.save({
             'model': policy.state_dict(),
@@ -147,7 +147,7 @@ def test_c51(args=get_args()):
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
         test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
-        resume_from_log=args.resume, save_train_fn=save_train_fn)
+        resume_from_log=args.resume, save_checkpoint_fn=save_checkpoint_fn)
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -148,7 +148,6 @@ def test_c51(args=get_args()):
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
         test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         resume_from_log=args.resume, save_train_fn=save_train_fn)
-
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -118,7 +118,7 @@ def test_c51(args=get_args()):
         # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
         torch.save({
             'model': policy.state_dict(),
-            'optim': policy.optim.state_dict(),
+            'optim': optim.state_dict(),
         }, os.path.join(log_path, 'checkpoint.pth'))
         pickle.dump(train_collector.buffer,
                     open(os.path.join(log_path, 'train_buffer.pkl'), "wb"))
@@ -136,8 +136,7 @@ def test_c51(args=get_args()):
             print("Fail to restore policy and optim.")
         buffer_path = os.path.join(log_path, 'train_buffer.pkl')
         if os.path.exists(buffer_path):
-            buffer = pickle.load(open(buffer_path, "rb"))
-            train_collector._assign_buffer(buffer)
+            train_collector.buffer = pickle.load(open(buffer_path, "rb"))
             print("Successfully restore buffer.")
         else:
             print("Fail to restore buffer.")

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -120,7 +120,6 @@ def test_dqn(args=get_args()):
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
         test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
-
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -44,6 +44,7 @@ def get_args():
     parser.add_argument(
         '--save-buffer-name', type=str,
         default="./expert_DQN_CartPole-v0.pkl")
+    parser.add_argument("--epoch-per-save", type=int, default=5)
     parser.add_argument(
         '--device', type=str,
         default='cuda' if torch.cuda.is_available() else 'cpu')
@@ -97,8 +98,39 @@ def test_dqn(args=get_args()):
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
+    def save_train_fn(policy, train_collector,
+                      test_collector, train_log, epoch):
+        # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
+        torch.save({
+            'epoch': epoch,
+            'model_state_dict': policy.state_dict(),
+            'optimizer_state_dict': policy.optim.state_dict(),
+            'train_log': train_log.state_dict()
+        }, os.path.join(log_path, 'checkpoint.pth'))
+        pickle.dump(train_collector.buffer,
+                    open(os.path.join(log_path, 'train_buffer.pkl'), "wb"))
+        # test collector does not need to be saved
+
+    def load_train_fn(policy, train_collector,
+                      test_collector, train_log):
+        # or use resume_path
+        print("Loaded agent from: ", log_path)
+        if os.path.exists(os.path.join(log_path, 'checkpoint.pth')) \
+                and os.path.exists(os.path.join(log_path, 'train_buffer.pkl')):
+            checkpoint = torch.load(
+                os.path.join(log_path, 'checkpoint.pth'), map_location=args.device
+            )
+            policy.load_state_dict(checkpoint['model_state_dict'])
+            policy.optim.load_state_dict(checkpoint['optimizer_state_dict'])
+            train_log.load_state_dict(checkpoint['train_log'])
+            buffer = pickle.load(open(os.path.join(log_path, 'train_buffer.pkl'), "rb"))
+            train_collector._assign_buffer(buffer)
+            return checkpoint['epoch'] + 1
+        return 1
+
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
+        # return False
 
     def train_fn(epoch, env_step):
         # eps annnealing, just a demo
@@ -119,7 +151,10 @@ def test_dqn(args=get_args()):
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, update_per_step=args.update_per_step, train_fn=train_fn,
-        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger)
+        test_fn=test_fn, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
+        save_train_fn=save_train_fn, load_train_fn=load_train_fn,
+        epoch_per_save=args.epoch_per_save
+    )
 
     assert stop_fn(result['best_reward'])
 

--- a/test/discrete/test_drqn.py
+++ b/test/discrete/test_drqn.py
@@ -99,8 +99,8 @@ def test_drqn(args=get_args()):
         args.batch_size, update_per_step=args.update_per_step,
         train_fn=train_fn, test_fn=test_fn, stop_fn=stop_fn,
         save_fn=save_fn, logger=logger)
-
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -43,6 +43,7 @@ def get_args():
         default="cuda" if torch.cuda.is_available() else "cpu",
     )
     parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--save-interval", type=int, default=4)
     args = parser.parse_known_args()[0]
     return args
 
@@ -86,7 +87,7 @@ def test_discrete_bcq(args=get_args()):
 
     log_path = os.path.join(args.logdir, args.task, 'discrete_bcq')
     writer = SummaryWriter(log_path)
-    logger = BasicLogger(writer)
+    logger = BasicLogger(writer, save_interval=args.save_interval)
 
     def save_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -68,7 +68,7 @@ def test_discrete_bcq(args=get_args()):
         args.state_shape, args.action_shape,
         hidden_sizes=args.hidden_sizes, device=args.device).to(args.device)
     optim = torch.optim.Adam(
-        set(policy_net.parameters()).union(imitation_net.parameters()),
+        list(policy_net.parameters()) + list(imitation_net.parameters()),
         lr=args.lr)
 
     policy = DiscreteBCQPolicy(
@@ -108,7 +108,7 @@ def test_discrete_bcq(args=get_args()):
         if os.path.exists(ckpt_path):
             checkpoint = torch.load(ckpt_path, map_location=args.device)
             policy.load_state_dict(checkpoint['model'])
-            # optim.load_state_dict(checkpoint['optim'])  # don't know why
+            optim.load_state_dict(checkpoint['optim'])
             print("Successfully restore policy and optim.")
         else:
             print("Fail to restore policy and optim.")
@@ -118,7 +118,6 @@ def test_discrete_bcq(args=get_args()):
         args.epoch, args.update_per_epoch, args.test_num, args.batch_size,
         stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         resume_from_log=args.resume, save_train_fn=save_train_fn)
-
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/discrete/test_il_bcq.py
+++ b/test/discrete/test_il_bcq.py
@@ -94,7 +94,7 @@ def test_discrete_bcq(args=get_args()):
     def stop_fn(mean_rewards):
         return mean_rewards >= env.spec.reward_threshold
 
-    def save_train_fn(epoch, env_step, gradient_step):
+    def save_checkpoint_fn(epoch, env_step, gradient_step):
         # see also: https://pytorch.org/tutorials/beginner/saving_loading_models.html
         torch.save({
             'model': policy.state_dict(),
@@ -117,7 +117,7 @@ def test_discrete_bcq(args=get_args()):
         policy, buffer, test_collector,
         args.epoch, args.update_per_epoch, args.test_num, args.batch_size,
         stop_fn=stop_fn, save_fn=save_fn, logger=logger,
-        resume_from_log=args.resume, save_train_fn=save_train_fn)
+        resume_from_log=args.resume, save_checkpoint_fn=save_checkpoint_fn)
     assert stop_fn(result['best_reward'])
 
     if __name__ == '__main__':

--- a/test/discrete/test_pg.py
+++ b/test/discrete/test_pg.py
@@ -93,6 +93,7 @@ def test_pg(args=get_args()):
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
         logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/discrete/test_ppo.py
+++ b/test/discrete/test_ppo.py
@@ -75,8 +75,8 @@ def test_ppo(args=get_args()):
         if isinstance(m, torch.nn.Linear):
             torch.nn.init.orthogonal_(m.weight)
             torch.nn.init.zeros_(m.bias)
-    optim = torch.optim.Adam(set(
-        actor.parameters()).union(critic.parameters()), lr=args.lr)
+    optim = torch.optim.Adam(
+        list(actor.parameters()) + list(critic.parameters()), lr=args.lr)
     dist = torch.distributions.Categorical
     policy = PPOPolicy(
         actor, critic, optim, dist,
@@ -113,6 +113,7 @@ def test_ppo(args=get_args()):
         episode_per_collect=args.episode_per_collect, stop_fn=stop_fn, save_fn=save_fn,
         logger=logger)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/discrete/test_qrdqn.py
+++ b/test/discrete/test_qrdqn.py
@@ -117,8 +117,8 @@ def test_qrdqn(args=get_args()):
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
         stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step)
-
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/test/discrete/test_sac.py
+++ b/test/discrete/test_sac.py
@@ -112,6 +112,7 @@ def test_discrete_sac(args=get_args()):
         args.batch_size, stop_fn=stop_fn, save_fn=save_fn, logger=logger,
         update_per_step=args.update_per_step, test_in_train=False)
     assert stop_fn(result['best_reward'])
+
     if __name__ == '__main__':
         pprint.pprint(result)
         # Let's watch its performance!

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -71,17 +71,16 @@ def offline_trainer(
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
     start_epoch, gradient_step = 0, 0
+    if resume_from_log:
+        start_epoch, _, gradient_step = logger.restore_data()
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     test_collector.reset_stat()
-    if resume_from_log:
-        best_epoch, best_reward, best_reward_std, start_epoch, _, \
-            gradient_step, _, _ = logger.restore_data()
-    else:
-        test_result = test_episode(policy, test_collector, test_fn, 0,
-                                   episode_per_test, logger, 0, reward_metric)
-        best_epoch = 0
-        best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
+
+    test_result = test_episode(policy, test_collector, test_fn, start_epoch,
+                               episode_per_test, logger, gradient_step, reward_metric)
+    best_epoch = start_epoch
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 
     for epoch in range(1 + start_epoch, 1 + max_epoch):
         policy.train()

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -21,9 +21,9 @@ def offline_trainer(
     test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
-    save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+    save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     resume_from_log: bool = False,
-    epoch_per_save: int = 1,
+    epoch_per_checkpoint: int = 1,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
@@ -47,12 +47,12 @@ def offline_trainer(
     :param function save_fn: a hook called when the undiscounted average mean reward in
         evaluation phase gets better, with the signature ``f(policy: BasePolicy) ->
         None``.
-    :param function save_train_fn: a function to save training process, with the
+    :param function save_checkpoint_fn: a function to save training process, with the
         signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``; you can
         save whatever you want. Because offline-RL doesn't have env_step, the env_step
         is always 0 here.
-    :param int epoch_per_save: save train process each ``epoch_per_save`` epoch by
-        calling ``save_train_fn``. Default to 1.
+    :param int epoch_per_checkpoint: save train process each ``epoch_per_checkpoint``
+        epoch by calling ``save_checkpoint_fn``. Default to 1.
     :param bool resume_from_log: resume gradient_step and other metadata from existing
         tensorboard log. Default to False.
     :param function stop_fn: a function with signature ``f(mean_rewards: float) ->
@@ -107,8 +107,8 @@ def offline_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
-            logger.save_data(epoch, 0, gradient_step, save_train_fn)
+        if epoch_per_checkpoint > 0 and epoch % epoch_per_checkpoint == 0:
+            logger.save_data(epoch, 0, gradient_step, save_checkpoint_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -107,8 +107,8 @@ def offline_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0 and save_train_fn:
-            save_train_fn(epoch, 0, gradient_step)
+        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
+            logger.save_data(epoch, 0, gradient_step, save_train_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -86,20 +86,18 @@ def offpolicy_trainer(
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
     start_epoch, env_step, gradient_step = 0, 0, 0
+    if resume_from_log:
+        start_epoch, env_step, gradient_step = logger.restore_data()
     last_rew, last_len = 0.0, 0
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     train_collector.reset_stat()
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
-    if resume_from_log:
-        best_epoch, best_reward, best_reward_std, start_epoch, env_step, \
-            gradient_step, last_rew, last_len = logger.restore_data()
-    else:
-        test_result = test_episode(policy, test_collector, test_fn, 0,
-                                   episode_per_test, logger, 0, reward_metric)
-        best_epoch = 0
-        best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
+    test_result = test_episode(policy, test_collector, test_fn, start_epoch,
+                               episode_per_test, logger, gradient_step, reward_metric)
+    best_epoch = start_epoch
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 
     for epoch in range(1 + start_epoch, 1 + max_epoch):
         # train

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -96,7 +96,7 @@ def offpolicy_trainer(
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
     test_result = test_episode(policy, test_collector, test_fn, start_epoch,
-                               episode_per_test, logger, gradient_step, reward_metric)
+                               episode_per_test, logger, env_step, reward_metric)
     best_epoch = start_epoch
     best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -24,9 +24,9 @@ def offpolicy_trainer(
     test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
-    save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+    save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     resume_from_log: bool = False,
-    epoch_per_save: int = 1,
+    epoch_per_checkpoint: int = 1,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
@@ -62,11 +62,11 @@ def offpolicy_trainer(
     :param function save_fn: a hook called when the undiscounted average mean reward in
         evaluation phase gets better, with the signature ``f(policy: BasePolicy) ->
         None``.
-    :param function save_train_fn: a function to save training process, with the
+    :param function save_checkpoint_fn: a function to save training process, with the
         signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``; you can
         save whatever you want.
-    :param int epoch_per_save: save train process each ``epoch_per_save`` epoch by
-        calling ``save_train_fn``. Default to 1.
+    :param int epoch_per_checkpoint: save train process each ``epoch_per_checkpoint``
+        epoch by calling ``save_checkpoint_fn``. Default to 1.
     :param bool resume_from_log: resume env_step/gradient_step and other metadata from
         existing tensorboard log. Default to False.
     :param function stop_fn: a function with signature ``f(mean_rewards: float) ->
@@ -134,7 +134,7 @@ def offpolicy_trainer(
                             if save_fn:
                                 save_fn(policy)
                             logger.save_data(
-                                epoch, env_step, gradient_step, save_train_fn)
+                                epoch, env_step, gradient_step, save_checkpoint_fn)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,
@@ -160,8 +160,8 @@ def offpolicy_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
-            logger.save_data(epoch, env_step, gradient_step, save_train_fn)
+        if epoch_per_checkpoint > 0 and epoch % epoch_per_checkpoint == 0:
+            logger.save_data(epoch, env_step, gradient_step, save_checkpoint_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -6,24 +6,8 @@ from typing import Dict, Union, Callable, Optional
 
 from tianshou.data import Collector
 from tianshou.policy import BasePolicy
-from tianshou.utils import tqdm_config, MovAvg, BaseLogger, LazyLogger
 from tianshou.trainer import test_episode, gather_info
-
-
-class TrainLog:
-    def __init__(self) -> None:
-        self.best_epoch = 0
-        self.best_reward, self.best_reward_std = 0, 0
-        self.gradient_step = 0
-        self.last_rew, self.last_len = 0.0, 0
-
-    def state_dict(self):
-        return self.__dict__
-
-    def load_state_dict(self, state_dict: dict):
-        for key in self.__dict__.keys():
-            if key in state_dict:
-                setattr(self, key, state_dict[key])
+from tianshou.utils import tqdm_config, MovAvg, BaseLogger, LazyLogger
 
 
 def offpolicy_trainer(
@@ -40,13 +24,9 @@ def offpolicy_trainer(
     test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
-    save_train_fn: Optional[
-        Callable[[BasePolicy, Collector, Collector, TrainLog, int], None]
-    ] = None,
-    load_train_fn: Optional[
-        Callable[[BasePolicy, Collector, Collector, TrainLog], int]
-    ] = None,
-    epoch_per_save: int = 0,
+    save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+    resume_from_log: bool = False,
+    epoch_per_save: int = 1,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
@@ -80,13 +60,15 @@ def offpolicy_trainer(
         It can be used to perform custom additional operations, with the signature ``f(
         num_epoch: int, step_idx: int) -> None``.
     :param function save_fn: a hook called when the undiscounted average mean reward in
-        evaluation phase gets better, with the signature ``f(policy:BasePolicy) ->
+        evaluation phase gets better, with the signature ``f(policy: BasePolicy) ->
         None``.
-    :param function save_train_fn: a function to save training process, you can save
-        whatever you want
-    :param function load_train_fn: a function called before train start, load whatever
-        you save, return epoch
-    :param int epoch_per_save: save train process each ``epoch_per_save`` epoch
+    :param function save_train_fn: a function to save training process, with the
+        signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``; you can
+        save whatever you want.
+    :param int epoch_per_save: save train process each ``epoch_per_save`` epoch by
+        calling ``save_train_fn``. Default to 1.
+    :param bool resume_from_log: resume env_step/gradient_step and other metadata from
+        existing tensorboard log. Default to False.
     :param function stop_fn: a function with signature ``f(mean_rewards: float) ->
         bool``, receives the average undiscounted returns of the testing result,
         returns a boolean which indicates whether reaching the goal.
@@ -103,26 +85,23 @@ def offpolicy_trainer(
 
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
-    train_log = TrainLog()
+    start_epoch, env_step, gradient_step = 0, 0, 0
+    last_rew, last_len = 0.0, 0
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     train_collector.reset_stat()
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
-
-    if load_train_fn:
-        epoch = load_train_fn(
-            policy, train_collector, test_collector, train_log
-        )
-        env_step = (epoch - 1) * step_per_epoch
+    if resume_from_log:
+        best_epoch, best_reward, best_reward_std, start_epoch, env_step, \
+            gradient_step, last_rew, last_len = logger.restore_data()
     else:
-        epoch, env_step = 1, 0
         test_result = test_episode(policy, test_collector, test_fn, 0,
                                    episode_per_test, logger, env_step, reward_metric)
-        train_log.best_reward, train_log.best_reward_std = \
-            test_result["rew"], test_result["rew_std"]
+        best_epoch = 0
+        best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 
-    for epoch in range(epoch, 1 + max_epoch):
+    for epoch in range(1 + start_epoch, 1 + max_epoch):
         # train
         policy.train()
         with tqdm.tqdm(
@@ -137,14 +116,12 @@ def offpolicy_trainer(
                 env_step += int(result["n/st"])
                 t.update(result["n/st"])
                 logger.log_train_data(result, env_step)
-                train_log.last_rew = \
-                    result['rew'] if 'rew' in result else train_log.last_rew
-                train_log.last_len = \
-                    result['len'] if 'len' in result else train_log.last_len
+                last_rew = result['rew'] if 'rew' in result else last_rew
+                last_len = result['len'] if 'len' in result else last_len
                 data = {
                     "env_step": str(env_step),
-                    "rew": f"{train_log.last_rew:.2f}",
-                    "len": str(int(train_log.last_len)),
+                    "rew": f"{last_rew:.2f}",
+                    "len": str(int(last_len)),
                     "n/ep": str(int(result["n/ep"])),
                     "n/st": str(int(result["n/st"])),
                 }
@@ -163,13 +140,13 @@ def offpolicy_trainer(
                         else:
                             policy.train()
                 for i in range(round(update_per_step * result["n/st"])):
-                    train_log.gradient_step += 1
+                    gradient_step += 1
                     losses = policy.update(batch_size, train_collector.buffer)
                     for k in losses.keys():
                         stat[k].add(losses[k])
                         losses[k] = stat[k].get()
                         data[k] = f"{losses[k]:.3f}"
-                    logger.log_update_data(losses, train_log.gradient_step)
+                    logger.log_update_data(losses, gradient_step)
                     t.set_postfix(**data)
             if t.n <= t.total:
                 t.update()
@@ -177,20 +154,16 @@ def offpolicy_trainer(
         test_result = test_episode(policy, test_collector, test_fn, epoch,
                                    episode_per_test, logger, env_step, reward_metric)
         rew, rew_std = test_result["rew"], test_result["rew_std"]
-        if train_log.best_epoch == -1 or train_log.best_reward < rew:
-            train_log.best_reward, train_log.best_reward_std = rew, rew_std
-            train_log.best_epoch = epoch
+        if best_epoch < 0 or best_reward < rew:
+            best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
         if epoch_per_save > 0 and epoch % epoch_per_save == 0 and save_train_fn:
-            save_train_fn(policy, train_collector, test_collector,
-                          train_log, epoch)
+            save_train_fn(epoch, env_step, gradient_step)
         if verbose:
-            print(
-                f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_reward:"
-                f" {train_log.best_reward:.6f} ± {train_log.best_reward_std:.6f}"
-                f" in #{train_log.best_epoch}")
-        if stop_fn and stop_fn(train_log.best_reward):
+            print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
+                  f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")
+        if stop_fn and stop_fn(best_reward):
             break
     return gather_info(start_time, train_collector, test_collector,
-                       train_log.best_reward, train_log.best_reward_std)
+                       best_reward, best_reward_std)

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -133,8 +133,8 @@ def offpolicy_trainer(
                         if stop_fn(test_result["rew"]):
                             if save_fn:
                                 save_fn(policy)
-                            if save_train_fn:
-                                save_train_fn(epoch, env_step, gradient_step)
+                            logger.save_data(
+                                epoch, env_step, gradient_step, save_train_fn)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,
@@ -160,8 +160,8 @@ def offpolicy_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0 and save_train_fn:
-            save_train_fn(epoch, env_step, gradient_step)
+        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
+            logger.save_data(epoch, env_step, gradient_step, save_train_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -133,6 +133,8 @@ def offpolicy_trainer(
                         if stop_fn(test_result["rew"]):
                             if save_fn:
                                 save_fn(policy)
+                            if save_train_fn:
+                                save_train_fn(epoch, env_step, gradient_step)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -97,7 +97,7 @@ def offpolicy_trainer(
             gradient_step, last_rew, last_len = logger.restore_data()
     else:
         test_result = test_episode(policy, test_collector, test_fn, 0,
-                                   episode_per_test, logger, env_step, reward_metric)
+                                   episode_per_test, logger, 0, reward_metric)
         best_epoch = 0
         best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -25,9 +25,9 @@ def onpolicy_trainer(
     test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
     stop_fn: Optional[Callable[[float], bool]] = None,
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
-    save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+    save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     resume_from_log: bool = False,
-    epoch_per_save: int = 1,
+    epoch_per_checkpoint: int = 1,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
@@ -64,11 +64,11 @@ def onpolicy_trainer(
     :param function save_fn: a hook called when the undiscounted average mean reward in
         evaluation phase gets better, with the signature ``f(policy: BasePolicy) ->
         None``.
-    :param function save_train_fn: a function to save training process, with the
+    :param function save_checkpoint_fn: a function to save training process, with the
         signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``; you can
         save whatever you want.
-    :param int epoch_per_save: save train process each ``epoch_per_save`` epoch by
-        calling ``save_train_fn``. Default to 1.
+    :param int epoch_per_checkpoint: save train process each ``epoch_per_checkpoint``
+        epoch by calling ``save_checkpoint_fn``. Default to 1.
     :param bool resume_from_log: resume env_step/gradient_step and other metadata from
         existing tensorboard log. Default to False.
     :param function stop_fn: a function with signature ``f(mean_rewards: float) ->
@@ -141,7 +141,7 @@ def onpolicy_trainer(
                             if save_fn:
                                 save_fn(policy)
                             logger.save_data(
-                                epoch, env_step, gradient_step, save_train_fn)
+                                epoch, env_step, gradient_step, save_checkpoint_fn)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,
@@ -171,8 +171,8 @@ def onpolicy_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
-            logger.save_data(epoch, env_step, gradient_step, save_train_fn)
+        if epoch_per_checkpoint > 0 and epoch % epoch_per_checkpoint == 0:
+            logger.save_data(epoch, env_step, gradient_step, save_checkpoint_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -92,20 +92,18 @@ def onpolicy_trainer(
         Only either one of step_per_collect and episode_per_collect can be specified.
     """
     start_epoch, env_step, gradient_step = 0, 0, 0
+    if resume_from_log:
+        start_epoch, env_step, gradient_step = logger.restore_data()
     last_rew, last_len = 0.0, 0
     stat: Dict[str, MovAvg] = defaultdict(MovAvg)
     start_time = time.time()
     train_collector.reset_stat()
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
-    if resume_from_log:
-        best_epoch, best_reward, best_reward_std, start_epoch, env_step, \
-            gradient_step, last_rew, last_len = logger.restore_data()
-    else:
-        test_result = test_episode(policy, test_collector, test_fn, 0,
-                                   episode_per_test, logger, 0, reward_metric)
-        best_epoch = 0
-        best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
+    test_result = test_episode(policy, test_collector, test_fn, start_epoch,
+                               episode_per_test, logger, gradient_step, reward_metric)
+    best_epoch = start_epoch
+    best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 
     for epoch in range(1 + start_epoch, 1 + max_epoch):
         # train

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -1,5 +1,6 @@
 import time
 import tqdm
+import warnings
 import numpy as np
 from collections import defaultdict
 from typing import Dict, Union, Callable, Optional
@@ -27,7 +28,6 @@ def onpolicy_trainer(
     save_fn: Optional[Callable[[BasePolicy], None]] = None,
     save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     resume_from_log: bool = False,
-    epoch_per_checkpoint: int = 1,
     reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     logger: BaseLogger = LazyLogger(),
     verbose: bool = True,
@@ -67,8 +67,6 @@ def onpolicy_trainer(
     :param function save_checkpoint_fn: a function to save training process, with the
         signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``; you can
         save whatever you want.
-    :param int epoch_per_checkpoint: save train process each ``epoch_per_checkpoint``
-        epoch by calling ``save_checkpoint_fn``. Default to 1.
     :param bool resume_from_log: resume env_step/gradient_step and other metadata from
         existing tensorboard log. Default to False.
     :param function stop_fn: a function with signature ``f(mean_rewards: float) ->
@@ -91,6 +89,9 @@ def onpolicy_trainer(
 
         Only either one of step_per_collect and episode_per_collect can be specified.
     """
+    if save_fn:
+        warnings.warn("Please consider using save_checkpoint_fn instead of save_fn.")
+
     start_epoch, env_step, gradient_step = 0, 0, 0
     if resume_from_log:
         start_epoch, env_step, gradient_step = logger.restore_data()
@@ -169,8 +170,7 @@ def onpolicy_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_checkpoint > 0 and epoch % epoch_per_checkpoint == 0:
-            logger.save_data(epoch, env_step, gradient_step, save_checkpoint_fn)
+        logger.save_data(epoch, env_step, gradient_step, save_checkpoint_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -103,7 +103,7 @@ def onpolicy_trainer(
             gradient_step, last_rew, last_len = logger.restore_data()
     else:
         test_result = test_episode(policy, test_collector, test_fn, 0,
-                                   episode_per_test, logger, env_step, reward_metric)
+                                   episode_per_test, logger, 0, reward_metric)
         best_epoch = 0
         best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -140,8 +140,8 @@ def onpolicy_trainer(
                         if stop_fn(test_result["rew"]):
                             if save_fn:
                                 save_fn(policy)
-                            if save_train_fn:
-                                save_train_fn(epoch, env_step, gradient_step)
+                            logger.save_data(
+                                epoch, env_step, gradient_step, save_train_fn)
                             t.set_postfix(**data)
                             return gather_info(
                                 start_time, train_collector, test_collector,
@@ -171,8 +171,8 @@ def onpolicy_trainer(
             best_epoch, best_reward, best_reward_std = epoch, rew, rew_std
             if save_fn:
                 save_fn(policy)
-        if epoch_per_save > 0 and epoch % epoch_per_save == 0 and save_train_fn:
-            save_train_fn(epoch, env_step, gradient_step)
+        if epoch_per_save > 0 and epoch % epoch_per_save == 0:
+            logger.save_data(epoch, env_step, gradient_step, save_train_fn)
         if verbose:
             print(f"Epoch #{epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, best_rew"
                   f"ard: {best_reward:.6f} ± {best_reward_std:.6f} in #{best_epoch}")

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -102,7 +102,7 @@ def onpolicy_trainer(
     test_collector.reset_stat()
     test_in_train = test_in_train and train_collector.policy == policy
     test_result = test_episode(policy, test_collector, test_fn, start_epoch,
-                               episode_per_test, logger, gradient_step, reward_metric)
+                               episode_per_test, logger, env_step, reward_metric)
     best_epoch = start_epoch
     best_reward, best_reward_std = test_result["rew"], test_result["rew_std"]
 

--- a/tianshou/trainer/utils.py
+++ b/tianshou/trainer/utils.py
@@ -27,7 +27,7 @@ def test_episode(
     if reward_metric:
         result["rews"] = reward_metric(result["rews"])
     if logger and global_step is not None:
-        logger.log_test_data(result, global_step, epoch)
+        logger.log_test_data(result, global_step)
     return result
 
 

--- a/tianshou/trainer/utils.py
+++ b/tianshou/trainer/utils.py
@@ -27,7 +27,7 @@ def test_episode(
     if reward_metric:
         result["rews"] = reward_metric(result["rews"])
     if logger and global_step is not None:
-        logger.log_test_data(result, global_step)
+        logger.log_test_data(result, global_step, epoch)
     return result
 
 

--- a/tianshou/utils/log_tools.py
+++ b/tianshou/utils/log_tools.py
@@ -60,18 +60,18 @@ class BaseLogger(ABC):
         epoch: int,
         env_step: int,
         gradient_step: int,
-        save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+        save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     ) -> None:
-        """Use writer to log metadata when calling ``save_train_fn`` in trainer.
+        """Use writer to log metadata when calling ``save_checkpoint_fn`` in trainer.
 
         :param int epoch: the epoch in trainer.
         :param int env_step: the env_step in trainer.
         :param int gradient_step: the gradient_step in trainer.
-        :param function save_train_fn: a hook defined by user, see trainer
+        :param function save_checkpoint_fn: a hook defined by user, see trainer
             documentation for detail.
         """
-        if save_train_fn:
-            save_train_fn(epoch, env_step, gradient_step)
+        if save_checkpoint_fn:
+            save_checkpoint_fn(epoch, env_step, gradient_step)
 
     def restore_data(self) -> Tuple[int, float, float, int, int, int, float, int]:
         """Return the metadata from existing log.
@@ -173,9 +173,9 @@ class BasicLogger(BaseLogger):
         epoch: int,
         env_step: int,
         gradient_step: int,
-        save_train_fn: Optional[Callable[[int, int, int], None]] = None,
+        save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
     ) -> None:
-        super().save_data(epoch, env_step, gradient_step, save_train_fn)
+        super().save_data(epoch, env_step, gradient_step, save_checkpoint_fn)
         self.write("save/epoch", epoch, epoch)
         self.write("save/env_step", env_step, env_step)
         self.write("save/gradient_step", gradient_step, gradient_step)


### PR DESCRIPTION
This is my simple idea: put everything (best_epoch and so on) in a class (TrainLog), and load/save all these things with hooked functions. I use a param ``epoch-per-save`` to save all these things every ``epoch-per-save`` epoch.

But the problem is that the loggers log every n step/epoch, and we restart our training process from ``k * epoch-per-save * step-per-epoch`` env_step, so the loggers will write reduplicative log. I wonder if we can log only when saving the training data.