### PR TITLE
support arrays with different shape in batch

### DIFF
--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -526,7 +526,12 @@ class Batch:
             elif all(isinstance(e, (Batch, dict)) for e in v):  # third often
                 self.__dict__[k] = Batch.stack(v, axis)
             else:  # most often case is np.ndarray
-                self.__dict__[k] = _to_array_with_correct_type(np.stack(v, axis))
+                try:
+                    self.__dict__[k] = _to_array_with_correct_type(np.stack(v, axis))
+                except ValueError:
+                    warnings.warn("You are using tensors with different shape,"
+                                  " fallback to dtype=object by default.")
+                    self.__dict__[k] = np.array(v, dtype=object)
         # all the keys
         keys_total = set.union(*[set(b.keys()) for b in batches])
         # keys that are reserved in all batches

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -259,7 +259,12 @@ class Collector(object):
                 obs_reset = self.env.reset(env_ind_global)
                 if self.preprocess_fn:
                     obs_reset = self.preprocess_fn(obs=obs_reset).get("obs", obs_reset)
-                self.data.obs_next[env_ind_local] = obs_reset
+                try:
+                    self.data.obs_next[env_ind_local] = obs_reset
+                except ValueError:
+                    _alloc_by_keys_diff(self.data, Batch(obs_next=obs_reset),
+                                        len(self.data), False)
+                    self.data.obs_next[env_ind_local] = obs_reset
                 for i in env_ind_local:
                     self._reset_state(i)
 


### PR DESCRIPTION
partially resolve #362 but I'm not sure if it can work in general cases. Test code:

```python
import gym
import numpy as np
import networkx as nx
from tianshou.data import Batch, VectorReplayBuffer
from tianshou.env import DummyVectorEnv, SubprocVectorEnv


class GraphEnv(gym.Env):
    def __init__(self, size):
        self.size = size
        self.feat_dim = 32
        # generate a random graph with size number of nodes
        self.graph = nx.random_regular_graph(2, size)

    def reset(self):
        # node feats
        node_feats = np.random.rand(self.size, self.feat_dim)
        edge_list = np.array(self.graph.edges())
        print(edge_list.shape, node_feats.shape, edge_list.dtype)
        return {"edge_list": np.asarray(edge_list, dtype=object), "node_feats": node_feats}

    def step(self, action):
        node_feats = np.random.rand(
            self.size, self.feat_dim)
        edge_list = np.array(self.graph.edges())
        print(edge_list.shape, node_feats.shape)
        return {"edge_list": np.asarray(edge_list, dtype=object), "node_feats": node_feats}, 1, False, {}

    def seed(self, seed=None):
        pass


if __name__ == '__main__':
    # train_envs = SubprocVectorEnv([lambda: GraphEnv(i) for i in [5, 10, 15]])
    train_envs = DummyVectorEnv([lambda i=x: GraphEnv(size=i) for x in [5, 10, 15]])

    env_obs = train_envs.reset()
    b = VectorReplayBuffer(total_size=3, buffer_num=3)

    b.add(Batch(obs=env_obs, act=[0, 0, 0], rew=[0, 0, 0],
                done=[0, 0, 0]), buffer_ids=np.arange(len(env_obs)))
    print(b[[1, 2]].obs.shape)
```