### PR TITLE
Remove warnings about the use of save_fn across trainers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
             "pydocstyle",
             "doc8",
         ],
-        "atari": ["atari_py", "cv2"],
+        "atari": ["atari_py", "opencv-python"],
         "mujoco": ["mujoco_py"],
         "pybullet": ["pybullet"],
     },

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -1,6 +1,5 @@
 import time
 import tqdm
-import warnings
 import numpy as np
 from collections import defaultdict
 from typing import Dict, Union, Callable, Optional
@@ -68,8 +67,6 @@ def offline_trainer(
 
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
-    if save_fn:
-        warnings.warn("Please consider using save_checkpoint_fn instead of save_fn.")
 
     start_epoch, gradient_step = 0, 0
     if resume_from_log:

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -67,7 +67,6 @@ def offline_trainer(
 
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
-
     start_epoch, gradient_step = 0, 0
     if resume_from_log:
         start_epoch, _, gradient_step = logger.restore_data()

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -1,6 +1,5 @@
 import time
 import tqdm
-import warnings
 import numpy as np
 from collections import defaultdict
 from typing import Dict, Union, Callable, Optional
@@ -83,8 +82,6 @@ def offpolicy_trainer(
 
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
-    if save_fn:
-        warnings.warn("Please consider using save_checkpoint_fn instead of save_fn.")
 
     start_epoch, env_step, gradient_step = 0, 0, 0
     if resume_from_log:

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -82,7 +82,6 @@ def offpolicy_trainer(
 
     :return: See :func:`~tianshou.trainer.gather_info`.
     """
-
     start_epoch, env_step, gradient_step = 0, 0, 0
     if resume_from_log:
         start_epoch, env_step, gradient_step = logger.restore_data()

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -1,6 +1,5 @@
 import time
 import tqdm
-import warnings
 import numpy as np
 from collections import defaultdict
 from typing import Dict, Union, Callable, Optional
@@ -89,8 +88,6 @@ def onpolicy_trainer(
 
         Only either one of step_per_collect and episode_per_collect can be specified.
     """
-    if save_fn:
-        warnings.warn("Please consider using save_checkpoint_fn instead of save_fn.")
 
     start_epoch, env_step, gradient_step = 0, 0, 0
     if resume_from_log:

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -88,7 +88,6 @@ def onpolicy_trainer(
 
         Only either one of step_per_collect and episode_per_collect can be specified.
     """
-
     start_epoch, env_step, gradient_step = 0, 0, 0
     if resume_from_log:
         start_epoch, env_step, gradient_step = logger.restore_data()


### PR DESCRIPTION
Fixes #396 by removing all warnings related to the use of `save_fn` in the trainers.
I've tested the onpolicy trainer modification, no issues. Other trainers have identical changes.

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [x] I have visited the [source website](https://github.com/thu-ml/tianshou)
- [x] I have searched through the [issue tracker](https://github.com/thu-ml/tianshou/issues) for duplicates
