### PR TITLE
Remove reset_buffer() from reset method

### DIFF
--- a/tianshou/data/buffer/base.py
+++ b/tianshou/data/buffer/base.py
@@ -96,7 +96,7 @@ class ReplayBuffer:
         """Load replay buffer from HDF5 file."""
         with h5py.File(path, "r") as f:
             buf = cls.__new__(cls)
-            buf.__setstate__(from_hdf5(f, device=device))
+            buf.__setstate__(from_hdf5(f, device=device))  # type: ignore
         return buf
 
     def reset(self, keep_statistics: bool = False) -> None:

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -73,7 +73,7 @@ class Collector(object):
         self.preprocess_fn = preprocess_fn
         self._action_space = env.action_space
         # avoid creating attribute outside __init__
-        self.reset()
+        self.reset(False)
 
     def _assign_buffer(self, buffer: Optional[ReplayBuffer]) -> None:
         """Check if the buffer matches the constraint."""
@@ -99,11 +99,11 @@ class Collector(object):
                 )
         self.buffer = buffer
 
-    def reset(self) -> None:
-        """Reset the environment, statistics and current data.
+    def reset(self, reset_buffer: bool = True) -> None:
+        """Reset the environment, statistics, current data and possibly replay memory.
 
-        This method will *not* reset the replay buffer.
-        If you would like to reset the buffer, call `collector.reset_buffer()`.
+        :param bool reset_buffer: if true, reset the replay buffer that is attached
+            to the collector.
         """
         # use empty Batch for "state" so that self.data supports slicing
         # convert empty Batch to None when passing data to policy
@@ -111,6 +111,8 @@ class Collector(object):
             obs={}, act={}, rew={}, done={}, obs_next={}, info={}, policy={}
         )
         self.reset_env()
+        if reset_buffer:
+            self.reset_buffer()
         self.reset_stat()
 
     def reset_stat(self) -> None:

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -50,7 +50,6 @@ class Collector(object):
     .. note::
         In past versions of Tianshou, the replay buffer that was passed to `__init__`
         was automatically reset. This is not done in the current implementation.
-        Moreover, the `reset` method no longer resets the replay buffer.
     """
 
     def __init__(

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -100,10 +100,10 @@ class Collector(object):
         self.buffer = buffer
 
     def reset(self) -> None:
-        """
-        Reset the environment, statistics and current data. This method will *not*
-        reset the replay buffer. If you would like to reset the buffer,
-        call `collector.reset_buffer()`.
+        """Reset the environment, statistics and current data.
+
+        This method will *not* reset the replay buffer.
+        If you would like to reset the buffer, call `collector.reset_buffer()`.
         """
         # use empty Batch for "state" so that self.data supports slicing
         # convert empty Batch to None when passing data to policy

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -46,6 +46,11 @@ class Collector(object):
 
         Please make sure the given environment has a time limitation if using n_episode
         collect option.
+
+    .. note::
+        In past versions of Tianshou, the replay buffer that was passed to `__init__`
+        was automatically reset. This is not done in the current implementation.
+        Moreover, the `reset` method no longer resets the replay buffer.
     """
 
     def __init__(
@@ -95,14 +100,17 @@ class Collector(object):
         self.buffer = buffer
 
     def reset(self) -> None:
-        """Reset all related variables in the collector."""
+        """
+        Reset the environment, statistics and current data. This method will *not*
+        reset the replay buffer. If you would like to reset the buffer,
+        call `collector.reset_buffer()`.
+        """
         # use empty Batch for "state" so that self.data supports slicing
         # convert empty Batch to None when passing data to policy
         self.data = Batch(
             obs={}, act={}, rew={}, done={}, obs_next={}, info={}, policy={}
         )
         self.reset_env()
-        self.reset_buffer()
         self.reset_stat()
 
     def reset_stat(self) -> None:

--- a/tianshou/utils/net/continuous.py
+++ b/tianshou/utils/net/continuous.py
@@ -48,8 +48,12 @@ class Actor(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim,  # type: ignore
-                        self.output_dim, hidden_sizes, device=self.device)
+        self.last = MLP(
+            input_dim,  # type: ignore
+            self.output_dim,
+            hidden_sizes,
+            device=self.device
+        )
         self._max = max_action
 
     def forward(
@@ -97,8 +101,12 @@ class Critic(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = 1
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim,  # type: ignore
-                        1, hidden_sizes, device=self.device)
+        self.last = MLP(
+            input_dim,  # type: ignore
+            1,
+            hidden_sizes,
+            device=self.device
+        )
 
     def forward(
         self,
@@ -167,12 +175,20 @@ class ActorProb(nn.Module):
         self.device = device
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.mu = MLP(input_dim,  # type: ignore
-                      self.output_dim, hidden_sizes, device=self.device)
+        self.mu = MLP(
+            input_dim,  # type: ignore
+            self.output_dim,
+            hidden_sizes,
+            device=self.device
+        )
         self._c_sigma = conditioned_sigma
         if conditioned_sigma:
-            self.sigma = MLP(input_dim,  # type: ignore
-                             self.output_dim, hidden_sizes, device=self.device)
+            self.sigma = MLP(
+                input_dim,  # type: ignore
+                self.output_dim,
+                hidden_sizes,
+                device=self.device
+            )
         else:
             self.sigma_param = nn.Parameter(torch.zeros(self.output_dim, 1))
         self._max = max_action

--- a/tianshou/utils/net/continuous.py
+++ b/tianshou/utils/net/continuous.py
@@ -48,7 +48,8 @@ class Actor(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim, self.output_dim, hidden_sizes, device=self.device)
+        self.last = MLP(input_dim,  # type: ignore
+                        self.output_dim, hidden_sizes, device=self.device)
         self._max = max_action
 
     def forward(
@@ -96,7 +97,8 @@ class Critic(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = 1
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim, 1, hidden_sizes, device=self.device)
+        self.last = MLP(input_dim,  # type: ignore
+                        1, hidden_sizes, device=self.device)
 
     def forward(
         self,
@@ -165,12 +167,12 @@ class ActorProb(nn.Module):
         self.device = device
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.mu = MLP(input_dim, self.output_dim, hidden_sizes, device=self.device)
+        self.mu = MLP(input_dim,  # type: ignore
+                      self.output_dim, hidden_sizes, device=self.device)
         self._c_sigma = conditioned_sigma
         if conditioned_sigma:
-            self.sigma = MLP(
-                input_dim, self.output_dim, hidden_sizes, device=self.device
-            )
+            self.sigma = MLP(input_dim,  # type: ignore
+                             self.output_dim, hidden_sizes, device=self.device)
         else:
             self.sigma_param = nn.Parameter(torch.zeros(self.output_dim, 1))
         self._max = max_action

--- a/tianshou/utils/net/discrete.py
+++ b/tianshou/utils/net/discrete.py
@@ -49,7 +49,8 @@ class Actor(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim, self.output_dim, hidden_sizes, device=self.device)
+        self.last = MLP(input_dim,  # type: ignore
+                        self.output_dim, hidden_sizes, device=self.device)
         self.softmax_output = softmax_output
 
     def forward(
@@ -101,7 +102,8 @@ class Critic(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = last_size
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim, last_size, hidden_sizes, device=self.device)
+        self.last = MLP(input_dim,  # type: ignore
+                        last_size, hidden_sizes, device=self.device)
 
     def forward(
         self, s: Union[np.ndarray, torch.Tensor], **kwargs: Any
@@ -183,8 +185,9 @@ class ImplicitQuantileNetwork(Critic):
         self.input_dim = getattr(
             preprocess_net, "output_dim", preprocess_net_output_dim
         )
-        self.embed_model = CosineEmbeddingNetwork(num_cosines,
-                                                  self.input_dim).to(device)
+        self.embed_model = CosineEmbeddingNetwork(
+            num_cosines, self.input_dim  # type: ignore
+        ).to(device)
 
     def forward(  # type: ignore
         self, s: Union[np.ndarray, torch.Tensor], sample_size: int, **kwargs: Any

--- a/tianshou/utils/net/discrete.py
+++ b/tianshou/utils/net/discrete.py
@@ -49,8 +49,12 @@ class Actor(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = int(np.prod(action_shape))
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim,  # type: ignore
-                        self.output_dim, hidden_sizes, device=self.device)
+        self.last = MLP(
+            input_dim,  # type: ignore
+            self.output_dim,
+            hidden_sizes,
+            device=self.device
+        )
         self.softmax_output = softmax_output
 
     def forward(
@@ -102,8 +106,12 @@ class Critic(nn.Module):
         self.preprocess = preprocess_net
         self.output_dim = last_size
         input_dim = getattr(preprocess_net, "output_dim", preprocess_net_output_dim)
-        self.last = MLP(input_dim,  # type: ignore
-                        last_size, hidden_sizes, device=self.device)
+        self.last = MLP(
+            input_dim,  # type: ignore
+            last_size,
+            hidden_sizes,
+            device=self.device
+        )
 
     def forward(
         self, s: Union[np.ndarray, torch.Tensor], **kwargs: Any
@@ -186,7 +194,8 @@ class ImplicitQuantileNetwork(Critic):
             preprocess_net, "output_dim", preprocess_net_output_dim
         )
         self.embed_model = CosineEmbeddingNetwork(
-            num_cosines, self.input_dim  # type: ignore
+            num_cosines,
+            self.input_dim  # type: ignore
         ).to(device)
 
     def forward(  # type: ignore


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [x] documentation modification
    + [x] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below

This pull request:
- Removes `self.reset_buffer()` from the `reset()` method
- Points out this change in the documentation

This was discussed in #500 


Best, Markus
