### PR TITLE
Fixing casts to int by to_torch_as(...) calls in policies when using discrete actions

### DIFF
--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -131,7 +131,7 @@ class PGPolicy(BasePolicy):
                 result = self(minibatch)
                 dist = result.dist
                 act = to_torch_as(minibatch.act, result.act)
-                ret = to_torch_as(minibatch.returns, result.act)
+                ret = to_torch(minibatch.returns, result.act.device, torch.float)
                 log_prob = dist.log_prob(act).reshape(len(ret), -1).transpose(0, 1)
                 loss = -(log_prob * ret).mean()
                 loss.backward()

--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 import numpy as np
 import torch
 
-from tianshou.data import Batch, ReplayBuffer, to_torch_as, to_torch
+from tianshou.data import Batch, ReplayBuffer, to_torch, to_torch_as
 from tianshou.policy import BasePolicy
 from tianshou.utils import RunningMeanStd
 

--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 import numpy as np
 import torch
 
-from tianshou.data import Batch, ReplayBuffer, to_torch_as
+from tianshou.data import Batch, ReplayBuffer, to_torch_as, to_torch
 from tianshou.policy import BasePolicy
 from tianshou.utils import RunningMeanStd
 

--- a/tianshou/policy/modelfree/pg.py
+++ b/tianshou/policy/modelfree/pg.py
@@ -131,7 +131,7 @@ class PGPolicy(BasePolicy):
                 result = self(minibatch)
                 dist = result.dist
                 act = to_torch_as(minibatch.act, result.act)
-                ret = to_torch(minibatch.returns, result.act.device, torch.float)
+                ret = to_torch(minibatch.returns, torch.float, result.act.device)
                 log_prob = dist.log_prob(act).reshape(len(ret), -1).transpose(0, 1)
                 loss = -(log_prob * ret).mean()
                 loss.backward()


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below

related issue: #520
