### PR TITLE
Replace log_alpha with alpha in SAC alpha_loss

### DIFF
--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -364,6 +364,7 @@ class AsyncCollector(Collector):
         exploration_noise: bool = False,
     ) -> None:
         # assert env.is_async
+        warnings.warn("Using async setting may collect extra transitions into buffer.")
         super().__init__(policy, env, buffer, preprocess_fn, exploration_noise)
 
     def reset_env(self) -> None:
@@ -424,7 +425,6 @@ class AsyncCollector(Collector):
                 "Please specify at least one (either n_step or n_episode) "
                 "in AsyncCollector.collect()."
             )
-        warnings.warn("Using async setting may collect extra transitions into buffer.")
 
         ready_env_ids = self._ready_env_ids
 

--- a/tianshou/policy/modelfree/sac.py
+++ b/tianshou/policy/modelfree/sac.py
@@ -174,7 +174,8 @@ class SACPolicy(DDPGPolicy):
 
         if self._is_auto_alpha:
             log_prob = obs_result.log_prob.detach() + self._target_entropy
-            alpha_loss = -(self._log_alpha.exp() * log_prob).mean()
+            # please take a look at issue #258 if you'd like to change this line
+            alpha_loss = -(self._log_alpha * log_prob).mean()
             self._alpha_optim.zero_grad()
             alpha_loss.backward()
             self._alpha_optim.step()

--- a/tianshou/policy/modelfree/sac.py
+++ b/tianshou/policy/modelfree/sac.py
@@ -174,7 +174,7 @@ class SACPolicy(DDPGPolicy):
 
         if self._is_auto_alpha:
             log_prob = obs_result.log_prob.detach() + self._target_entropy
-            alpha_loss = -(self._log_alpha * log_prob).mean()
+            alpha_loss = -(self._log_alpha.exp() * log_prob).mean()
             self._alpha_optim.zero_grad()
             alpha_loss.backward()
             self._alpha_optim.step()


### PR DESCRIPTION
- [X] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [X] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the code using `make commit-checks` (**required**)
- [ ] If applicable, I have mentioned the relevant/related issue(s)
- [ ] If applicable, I have listed every items in this Pull Request below

The loss function for alpha in the paper (https://arxiv.org/pdf/1812.05905.pdf, eq. 18) multiplies the loss by alpha, but the current implementation multiplies by log(alpha). I updated the loss top match eq.18 from the paper.
