### PR TITLE
rename save_fn to save_best_fn to avoid ambiguity

### DIFF
--- a/docs/tutorials/tictactoe.rst
+++ b/docs/tutorials/tictactoe.rst
@@ -327,7 +327,7 @@ With the above preparation, we are close to the first learned agent. The followi
 
     # ======== callback functions used during training =========
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         if hasattr(args, 'model_save_path'):
             model_save_path = args.model_save_path
         else:
@@ -358,8 +358,9 @@ With the above preparation, we are close to the first learned agent. The followi
         policy, train_collector, test_collector, args.epoch,
         args.step_per_epoch, args.step_per_collect, args.test_num,
         args.batch_size, train_fn=train_fn, test_fn=test_fn,
-        stop_fn=stop_fn, save_fn=save_fn, update_per_step=args.update_per_step,
-        logger=logger, test_in_train=False, reward_metric=reward_metric)
+        stop_fn=stop_fn, save_best_fn=save_best_fn,
+        update_per_step=args.update_per_step, logger=logger,
+        test_in_train=False, reward_metric=reward_metric)
 
     agent = policy.policies[args.agent_id - 1]
     # let's watch the match!

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -133,7 +133,7 @@ def test_c51(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -206,7 +206,7 @@ def test_c51(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -165,7 +165,7 @@ def test_dqn(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -244,7 +244,7 @@ def test_dqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/atari/atari_fqf.py
+++ b/examples/atari/atari_fqf.py
@@ -150,7 +150,7 @@ def test_fqf(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -223,7 +223,7 @@ def test_fqf(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/atari/atari_iqn.py
+++ b/examples/atari/atari_iqn.py
@@ -145,7 +145,7 @@ def test_iqn(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -218,7 +218,7 @@ def test_iqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/atari/atari_ppo.py
+++ b/examples/atari/atari_ppo.py
@@ -209,7 +209,7 @@ def test_ppo(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -272,7 +272,7 @@ def test_ppo(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         test_in_train=False,
         resume_from_log=args.resume_id is not None,

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -129,7 +129,7 @@ def test_qrdqn(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -202,7 +202,7 @@ def test_qrdqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/atari/atari_rainbow.py
+++ b/examples/atari/atari_rainbow.py
@@ -162,7 +162,7 @@ def test_rainbow(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -246,7 +246,7 @@ def test_rainbow(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False,

--- a/examples/box2d/acrobot_dualdqn.py
+++ b/examples/box2d/acrobot_dualdqn.py
@@ -99,7 +99,7 @@ def test_dqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -132,7 +132,7 @@ def test_dqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/examples/box2d/bipedal_hardcore_sac.py
+++ b/examples/box2d/bipedal_hardcore_sac.py
@@ -161,7 +161,7 @@ def test_sac_bipedal(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -180,7 +180,7 @@ def test_sac_bipedal(args=get_args()):
         update_per_step=args.update_per_step,
         test_in_train=False,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/examples/box2d/lunarlander_dqn.py
+++ b/examples/box2d/lunarlander_dqn.py
@@ -100,7 +100,7 @@ def test_dqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -127,7 +127,7 @@ def test_dqn(args=get_args()):
         stop_fn=stop_fn,
         train_fn=train_fn,
         test_fn=test_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/examples/box2d/mcc_sac.py
+++ b/examples/box2d/mcc_sac.py
@@ -128,7 +128,7 @@ def test_sac(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -146,7 +146,7 @@ def test_sac(args=get_args()):
         args.batch_size,
         update_per_step=args.update_per_step,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/examples/inverse/irl_gail.py
+++ b/examples/inverse/irl_gail.py
@@ -244,7 +244,7 @@ def test_gail(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=100, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -259,7 +259,7 @@ def test_gail(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/mujoco/mujoco_a2c.py
+++ b/examples/mujoco/mujoco_a2c.py
@@ -179,7 +179,7 @@ def test_a2c(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=100, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -194,7 +194,7 @@ def test_a2c(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/mujoco/mujoco_ddpg.py
+++ b/examples/mujoco/mujoco_ddpg.py
@@ -128,7 +128,7 @@ def test_ddpg(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -142,7 +142,7 @@ def test_ddpg(args=get_args()):
             args.step_per_collect,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             update_per_step=args.update_per_step,
             test_in_train=False

--- a/examples/mujoco/mujoco_npg.py
+++ b/examples/mujoco/mujoco_npg.py
@@ -175,7 +175,7 @@ def test_npg(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=100, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -190,7 +190,7 @@ def test_npg(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/mujoco/mujoco_ppo.py
+++ b/examples/mujoco/mujoco_ppo.py
@@ -186,7 +186,7 @@ def test_ppo(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=100, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -201,7 +201,7 @@ def test_ppo(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/mujoco/mujoco_reinforce.py
+++ b/examples/mujoco/mujoco_reinforce.py
@@ -158,7 +158,7 @@ def test_reinforce(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=10, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -173,7 +173,7 @@ def test_reinforce(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -151,7 +151,7 @@ def test_sac(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -165,7 +165,7 @@ def test_sac(args=get_args()):
             args.step_per_collect,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             update_per_step=args.update_per_step,
             test_in_train=False

--- a/examples/mujoco/mujoco_td3.py
+++ b/examples/mujoco/mujoco_td3.py
@@ -148,7 +148,7 @@ def test_td3(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -162,7 +162,7 @@ def test_td3(args=get_args()):
             args.step_per_collect,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             update_per_step=args.update_per_step,
             test_in_train=False

--- a/examples/mujoco/mujoco_trpo.py
+++ b/examples/mujoco/mujoco_trpo.py
@@ -180,7 +180,7 @@ def test_trpo(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer, update_interval=100, train_interval=100)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     if not args.watch:
@@ -195,7 +195,7 @@ def test_trpo(args=get_args()):
             args.test_num,
             args.batch_size,
             step_per_collect=args.step_per_collect,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
             test_in_train=False
         )

--- a/examples/offline/atari_bcq.py
+++ b/examples/offline/atari_bcq.py
@@ -150,7 +150,7 @@ def test_discrete_bcq(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -182,7 +182,7 @@ def test_discrete_bcq(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
 

--- a/examples/offline/atari_cql.py
+++ b/examples/offline/atari_cql.py
@@ -135,7 +135,7 @@ def test_discrete_cql(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -167,7 +167,7 @@ def test_discrete_cql(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
 

--- a/examples/offline/atari_crr.py
+++ b/examples/offline/atari_crr.py
@@ -155,7 +155,7 @@ def test_discrete_crr(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -186,7 +186,7 @@ def test_discrete_crr(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
 

--- a/examples/offline/atari_il.py
+++ b/examples/offline/atari_il.py
@@ -120,7 +120,7 @@ def test_il(args=get_args()):
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def stop_fn(mean_rewards):
@@ -151,7 +151,7 @@ def test_il(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
 

--- a/examples/offline/d4rl_bcq.py
+++ b/examples/offline/d4rl_bcq.py
@@ -196,7 +196,7 @@ def test_bcq():
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def watch():
@@ -237,7 +237,7 @@ def test_bcq():
             args.step_per_epoch,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
         )
         pprint.pprint(result)

--- a/examples/offline/d4rl_cql.py
+++ b/examples/offline/d4rl_cql.py
@@ -191,7 +191,7 @@ def test_cql():
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def watch():
@@ -232,7 +232,7 @@ def test_cql():
             args.step_per_epoch,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
         )
         pprint.pprint(result)

--- a/examples/offline/d4rl_il.py
+++ b/examples/offline/d4rl_il.py
@@ -133,7 +133,7 @@ def test_il():
     else:  # wandb
         logger.load(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, "policy.pth"))
 
     def watch():
@@ -174,7 +174,7 @@ def test_il():
             args.step_per_epoch,
             args.test_num,
             args.batch_size,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             logger=logger,
         )
         pprint.pprint(result)

--- a/examples/vizdoom/vizdoom_c51.py
+++ b/examples/vizdoom/vizdoom_c51.py
@@ -125,7 +125,7 @@ def test_c51(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -200,7 +200,7 @@ def test_c51(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False

--- a/examples/vizdoom/vizdoom_ppo.py
+++ b/examples/vizdoom/vizdoom_ppo.py
@@ -202,7 +202,7 @@ def test_ppo(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -261,7 +261,7 @@ def test_ppo(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         test_in_train=False
     )

--- a/test/continuous/test_ddpg.py
+++ b/test/continuous/test_ddpg.py
@@ -111,7 +111,7 @@ def test_ddpg(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -129,7 +129,7 @@ def test_ddpg(args=get_args()):
         args.batch_size,
         update_per_step=args.update_per_step,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/continuous/test_npg.py
+++ b/test/continuous/test_npg.py
@@ -134,7 +134,7 @@ def test_npg(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -152,7 +152,7 @@ def test_npg(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/continuous/test_ppo.py
+++ b/test/continuous/test_ppo.py
@@ -129,7 +129,7 @@ def test_ppo(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer, save_interval=args.save_interval)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -168,7 +168,7 @@ def test_ppo(args=get_args()):
         args.batch_size,
         episode_per_collect=args.episode_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume,
         save_checkpoint_fn=save_checkpoint_fn

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -138,7 +138,7 @@ def test_sac_with_il(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -156,7 +156,7 @@ def test_sac_with_il(args=get_args()):
         args.batch_size,
         update_per_step=args.update_per_step,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])
@@ -198,7 +198,7 @@ def test_sac_with_il(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/continuous/test_td3.py
+++ b/test/continuous/test_td3.py
@@ -129,7 +129,7 @@ def test_td3(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -147,7 +147,7 @@ def test_td3(args=get_args()):
         args.batch_size,
         update_per_step=args.update_per_step,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
     for epoch, epoch_stat, info in trainer:

--- a/test/continuous/test_trpo.py
+++ b/test/continuous/test_trpo.py
@@ -138,7 +138,7 @@ def test_trpo(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -156,7 +156,7 @@ def test_trpo(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -96,7 +96,7 @@ def test_a2c_with_il(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -114,7 +114,7 @@ def test_a2c_with_il(args=get_args()):
         args.batch_size,
         episode_per_collect=args.episode_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])
@@ -152,7 +152,7 @@ def test_a2c_with_il(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_c51.py
+++ b/test/discrete/test_c51.py
@@ -118,7 +118,7 @@ def test_c51(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer, save_interval=args.save_interval)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -183,7 +183,7 @@ def test_c51(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume,
         save_checkpoint_fn=save_checkpoint_fn

--- a/test/discrete/test_dqn.py
+++ b/test/discrete/test_dqn.py
@@ -109,7 +109,7 @@ def test_dqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -143,7 +143,7 @@ def test_dqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_drqn.py
+++ b/test/discrete/test_drqn.py
@@ -96,7 +96,7 @@ def test_drqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -122,7 +122,7 @@ def test_drqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_fqf.py
+++ b/test/discrete/test_fqf.py
@@ -126,7 +126,7 @@ def test_fqf(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -159,7 +159,7 @@ def test_fqf(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step
     )

--- a/test/discrete/test_iqn.py
+++ b/test/discrete/test_iqn.py
@@ -120,7 +120,7 @@ def test_iqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -153,7 +153,7 @@ def test_iqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step
     )

--- a/test/discrete/test_pg.py
+++ b/test/discrete/test_pg.py
@@ -97,7 +97,7 @@ def test_pg(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -115,7 +115,7 @@ def test_pg(args=get_args()):
         args.batch_size,
         episode_per_collect=args.episode_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_ppo.py
+++ b/test/discrete/test_ppo.py
@@ -122,7 +122,7 @@ def test_ppo(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -140,7 +140,7 @@ def test_ppo(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/discrete/test_qrdqn.py
+++ b/test/discrete/test_qrdqn.py
@@ -113,7 +113,7 @@ def test_qrdqn(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -146,7 +146,7 @@ def test_qrdqn(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
     )

--- a/test/discrete/test_rainbow.py
+++ b/test/discrete/test_rainbow.py
@@ -132,7 +132,7 @@ def test_rainbow(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer, save_interval=args.save_interval)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -207,7 +207,7 @@ def test_rainbow(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume,
         save_checkpoint_fn=save_checkpoint_fn

--- a/test/discrete/test_sac.py
+++ b/test/discrete/test_sac.py
@@ -114,7 +114,7 @@ def test_discrete_sac(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -131,7 +131,7 @@ def test_discrete_sac(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
         test_in_train=False

--- a/test/modelbased/test_dqn_icm.py
+++ b/test/modelbased/test_dqn_icm.py
@@ -148,7 +148,7 @@ def test_dqn_icm(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -182,7 +182,7 @@ def test_dqn_icm(args=get_args()):
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
     )
     assert stop_fn(result['best_reward'])

--- a/test/modelbased/test_ppo_icm.py
+++ b/test/modelbased/test_ppo_icm.py
@@ -154,7 +154,7 @@ def test_ppo(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -172,7 +172,7 @@ def test_ppo(args=get_args()):
         args.batch_size,
         step_per_collect=args.step_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
     assert stop_fn(result['best_reward'])

--- a/test/offline/gather_cartpole_data.py
+++ b/test/offline/gather_cartpole_data.py
@@ -117,7 +117,7 @@ def gather_data():
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -150,7 +150,7 @@ def gather_data():
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         update_per_step=args.update_per_step,
     )

--- a/test/offline/gather_pendulum_data.py
+++ b/test/offline/gather_pendulum_data.py
@@ -147,7 +147,7 @@ def gather_data():
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -164,7 +164,7 @@ def gather_data():
         args.test_num,
         args.batch_size,
         update_per_step=args.update_per_step,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         stop_fn=stop_fn,
         logger=logger,
     )

--- a/test/offline/test_bcq.py
+++ b/test/offline/test_bcq.py
@@ -181,7 +181,7 @@ def test_bcq(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -206,7 +206,7 @@ def test_bcq(args=get_args()):
         args.step_per_epoch,
         args.test_num,
         args.batch_size,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         stop_fn=stop_fn,
         logger=logger,
     )

--- a/test/offline/test_cql.py
+++ b/test/offline/test_cql.py
@@ -178,7 +178,7 @@ def test_cql(args=get_args()):
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -203,7 +203,7 @@ def test_cql(args=get_args()):
         args.step_per_epoch,
         args.test_num,
         args.batch_size,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         stop_fn=stop_fn,
         logger=logger,
     )

--- a/test/offline/test_discrete_bcq.py
+++ b/test/offline/test_discrete_bcq.py
@@ -108,7 +108,7 @@ def test_discrete_bcq(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer, save_interval=args.save_interval)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -144,7 +144,7 @@ def test_discrete_bcq(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume,
         save_checkpoint_fn=save_checkpoint_fn

--- a/test/offline/test_discrete_cql.py
+++ b/test/offline/test_discrete_cql.py
@@ -103,7 +103,7 @@ def test_discrete_cql(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -118,7 +118,7 @@ def test_discrete_cql(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/test/offline/test_discrete_crr.py
+++ b/test/offline/test_discrete_crr.py
@@ -106,7 +106,7 @@ def test_discrete_crr(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -121,7 +121,7 @@ def test_discrete_crr(args=get_args()):
         args.test_num,
         args.batch_size,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger
     )
 

--- a/test/offline/test_gail.py
+++ b/test/offline/test_gail.py
@@ -167,7 +167,7 @@ def test_gail(args=get_args()):
     writer = SummaryWriter(log_path)
     logger = TensorboardLogger(writer, save_interval=args.save_interval)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         torch.save(policy.state_dict(), os.path.join(log_path, 'policy.pth'))
 
     def stop_fn(mean_rewards):
@@ -206,7 +206,7 @@ def test_gail(args=get_args()):
         args.batch_size,
         episode_per_collect=args.episode_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume,
         save_checkpoint_fn=save_checkpoint_fn,

--- a/test/pettingzoo/pistonball.py
+++ b/test/pettingzoo/pistonball.py
@@ -135,7 +135,7 @@ def train_agent(
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         pass
 
     def stop_fn(mean_rewards):
@@ -163,7 +163,7 @@ def train_agent(
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         update_per_step=args.update_per_step,
         logger=logger,
         test_in_train=False,

--- a/test/pettingzoo/pistonball_continuous.py
+++ b/test/pettingzoo/pistonball_continuous.py
@@ -230,7 +230,7 @@ def train_agent(
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         pass
 
     def stop_fn(mean_rewards):
@@ -257,7 +257,7 @@ def train_agent(
         args.batch_size,
         episode_per_collect=args.episode_per_collect,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         logger=logger,
         resume_from_log=args.resume
     )

--- a/test/pettingzoo/tic_tac_toe.py
+++ b/test/pettingzoo/tic_tac_toe.py
@@ -178,7 +178,7 @@ def train_agent(
     writer.add_text("args", str(args))
     logger = TensorboardLogger(writer)
 
-    def save_fn(policy):
+    def save_best_fn(policy):
         if hasattr(args, 'model_save_path'):
             model_save_path = args.model_save_path
         else:
@@ -214,7 +214,7 @@ def train_agent(
         train_fn=train_fn,
         test_fn=test_fn,
         stop_fn=stop_fn,
-        save_fn=save_fn,
+        save_best_fn=save_best_fn,
         update_per_step=args.update_per_step,
         logger=logger,
         test_in_train=False,

--- a/tianshou/__init__.py
+++ b/tianshou/__init__.py
@@ -1,6 +1,6 @@
 from tianshou import data, env, exploration, policy, trainer, utils
 
-__version__ = "0.4.6.post1"
+__version__ = "0.4.7"
 
 __all__ = [
     "env",

--- a/tianshou/env/worker/base.py
+++ b/tianshou/env/worker/base.py
@@ -1,9 +1,10 @@
-import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
+
+from tianshou.utils import deprecation
 
 
 class EnvWorker(ABC):
@@ -33,7 +34,7 @@ class EnvWorker(ABC):
         function is determined by such kind of different signal.
         """
         if hasattr(self, "send_action"):
-            warnings.warn(
+            deprecation(
                 "send_action will soon be deprecated. "
                 "Please use send and recv for your own EnvWorker."
             )
@@ -54,7 +55,7 @@ class EnvWorker(ABC):
         info).
         """
         if hasattr(self, "get_result"):
-            warnings.warn(
+            deprecation(
                 "get_result will soon be deprecated. "
                 "Please use send and recv for your own EnvWorker."
             )

--- a/tianshou/trainer/offline.py
+++ b/tianshou/trainer/offline.py
@@ -28,9 +28,9 @@ class OfflineTrainer(BaseTrainer):
         epoch.
         It can be used to perform custom additional operations, with the signature
         ``f(num_epoch: int, step_idx: int) -> None``.
-    :param function save_fn: a hook called when the undiscounted average mean
+    :param function save_best_fn: a hook called when the undiscounted average mean
         reward in evaluation phase gets better, with the signature
-        ``f(policy: BasePolicy) -> None``.
+        ``f(policy: BasePolicy) -> None``. It was ``save_fn`` previously.
     :param function save_checkpoint_fn: a function to save training process,
         with the signature ``f(epoch: int, env_step: int, gradient_step: int) ->
         None``; you can save whatever you want. Because offline-RL doesn't have
@@ -64,12 +64,13 @@ class OfflineTrainer(BaseTrainer):
         batch_size: int,
         test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
         stop_fn: Optional[Callable[[float], bool]] = None,
-        save_fn: Optional[Callable[[BasePolicy], None]] = None,
+        save_best_fn: Optional[Callable[[BasePolicy], None]] = None,
         save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
         resume_from_log: bool = False,
         reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         logger: BaseLogger = LazyLogger(),
         verbose: bool = True,
+        **kwargs: Any,
     ):
         super().__init__(
             learning_type="offline",
@@ -83,12 +84,13 @@ class OfflineTrainer(BaseTrainer):
             batch_size=batch_size,
             test_fn=test_fn,
             stop_fn=stop_fn,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             save_checkpoint_fn=save_checkpoint_fn,
             resume_from_log=resume_from_log,
             reward_metric=reward_metric,
             logger=logger,
             verbose=verbose,
+            **kwargs,
         )
 
     def policy_update_fn(

--- a/tianshou/trainer/offpolicy.py
+++ b/tianshou/trainer/offpolicy.py
@@ -37,9 +37,9 @@ class OffpolicyTrainer(BaseTrainer):
     :param function test_fn: a hook called at the beginning of testing in each
         epoch. It can be used to perform custom additional operations, with the
         signature ``f(num_epoch: int, step_idx: int) -> None``.
-    :param function save_fn: a hook called when the undiscounted average mean
+    :param function save_best_fn: a hook called when the undiscounted average mean
         reward in evaluation phase gets better, with the signature
-        ``f(policy: BasePolicy) ->  None``.
+        ``f(policy: BasePolicy) ->  None``. It was ``save_fn`` previously.
     :param function save_checkpoint_fn: a function to save training process, with
         the signature ``f(epoch: int, env_step: int, gradient_step: int) -> None``;
         you can save whatever you want.
@@ -77,13 +77,14 @@ class OffpolicyTrainer(BaseTrainer):
         train_fn: Optional[Callable[[int, int], None]] = None,
         test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
         stop_fn: Optional[Callable[[float], bool]] = None,
-        save_fn: Optional[Callable[[BasePolicy], None]] = None,
+        save_best_fn: Optional[Callable[[BasePolicy], None]] = None,
         save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
         resume_from_log: bool = False,
         reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         logger: BaseLogger = LazyLogger(),
         verbose: bool = True,
         test_in_train: bool = True,
+        **kwargs: Any,
     ):
         super().__init__(
             learning_type="offpolicy",
@@ -99,13 +100,14 @@ class OffpolicyTrainer(BaseTrainer):
             train_fn=train_fn,
             test_fn=test_fn,
             stop_fn=stop_fn,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             save_checkpoint_fn=save_checkpoint_fn,
             resume_from_log=resume_from_log,
             reward_metric=reward_metric,
             logger=logger,
             verbose=verbose,
             test_in_train=test_in_train,
+            **kwargs,
         )
 
     def policy_update_fn(self, data: Dict[str, Any], result: Dict[str, Any]) -> None:

--- a/tianshou/trainer/onpolicy.py
+++ b/tianshou/trainer/onpolicy.py
@@ -39,9 +39,9 @@ class OnpolicyTrainer(BaseTrainer):
     :param function test_fn: a hook called at the beginning of testing in each
         epoch. It can be used to perform custom additional operations, with the
         signature ``f(num_epoch: int, step_idx: int) -> None``.
-    :param function save_fn: a hook called when the undiscounted average mean
+    :param function save_best_fn: a hook called when the undiscounted average mean
         reward in evaluation phase gets better, with the signature
-        ``f(policy: BasePolicy) -> None``.
+        ``f(policy: BasePolicy) -> None``. It was ``save_fn`` previously.
     :param function save_checkpoint_fn: a function to save training process,
         with the signature ``f(epoch: int, env_step: int, gradient_step: int)
         -> None``; you can save whatever you want.
@@ -85,13 +85,14 @@ class OnpolicyTrainer(BaseTrainer):
         train_fn: Optional[Callable[[int, int], None]] = None,
         test_fn: Optional[Callable[[int, Optional[int]], None]] = None,
         stop_fn: Optional[Callable[[float], bool]] = None,
-        save_fn: Optional[Callable[[BasePolicy], None]] = None,
+        save_best_fn: Optional[Callable[[BasePolicy], None]] = None,
         save_checkpoint_fn: Optional[Callable[[int, int, int], None]] = None,
         resume_from_log: bool = False,
         reward_metric: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         logger: BaseLogger = LazyLogger(),
         verbose: bool = True,
         test_in_train: bool = True,
+        **kwargs: Any,
     ):
         super().__init__(
             learning_type="onpolicy",
@@ -108,13 +109,14 @@ class OnpolicyTrainer(BaseTrainer):
             train_fn=train_fn,
             test_fn=test_fn,
             stop_fn=stop_fn,
-            save_fn=save_fn,
+            save_best_fn=save_best_fn,
             save_checkpoint_fn=save_checkpoint_fn,
             resume_from_log=resume_from_log,
             reward_metric=reward_metric,
             logger=logger,
             verbose=verbose,
             test_in_train=test_in_train,
+            **kwargs,
         )
 
     def policy_update_fn(

--- a/tianshou/utils/__init__.py
+++ b/tianshou/utils/__init__.py
@@ -5,8 +5,16 @@ from tianshou.utils.logger.base import BaseLogger, LazyLogger
 from tianshou.utils.logger.tensorboard import BasicLogger, TensorboardLogger
 from tianshou.utils.logger.wandb import WandbLogger
 from tianshou.utils.statistics import MovAvg, RunningMeanStd
+from tianshou.utils.warning import deprecation
 
 __all__ = [
-    "MovAvg", "RunningMeanStd", "tqdm_config", "BaseLogger", "TensorboardLogger",
-    "BasicLogger", "LazyLogger", "WandbLogger"
+    "MovAvg",
+    "RunningMeanStd",
+    "tqdm_config",
+    "BaseLogger",
+    "TensorboardLogger",
+    "BasicLogger",
+    "LazyLogger",
+    "WandbLogger",
+    "deprecation",
 ]

--- a/tianshou/utils/logger/tensorboard.py
+++ b/tianshou/utils/logger/tensorboard.py
@@ -1,10 +1,10 @@
-import warnings
 from typing import Any, Callable, Optional, Tuple
 
 from tensorboard.backend.event_processing import event_accumulator
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.utils.logger.base import LOG_DATA_TYPE, BaseLogger
+from tianshou.utils.warning import deprecation
 
 
 class TensorboardLogger(BaseLogger):
@@ -81,7 +81,8 @@ class BasicLogger(TensorboardLogger):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        warnings.warn(
-            "Deprecated soon: BasicLogger has renamed to TensorboardLogger in #427."
+        deprecation(
+            "Class BasicLogger is marked as deprecated and will be removed soon. "
+            "Please use TensorboardLogger instead."
         )
         super().__init__(*args, **kwargs)

--- a/tianshou/utils/warning.py
+++ b/tianshou/utils/warning.py
@@ -1,0 +1,8 @@
+import warnings
+
+warnings.simplefilter("once", DeprecationWarning)
+
+
+def deprecation(msg: str) -> None:
+    """Deprecation warning wrapper."""
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
This PR also introduces `tianshou.utils.deprecation` for a unified deprecation wrapper.