### PR TITLE
Add jupyter notebook tutorials using Google Colaboratory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,13 +94,13 @@ Tianshou is still under development, you can also check out the documents in sta
    :maxdepth: 1
    :caption: Tutorials
 
+   tutorials/get_started
    tutorials/dqn
    tutorials/concepts
    tutorials/batch
    tutorials/tictactoe
    tutorials/logger
    tutorials/benchmark
-   tutorials/get_started
    tutorials/cheatsheet
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ Tianshou is still under development, you can also check out the documents in sta
    tutorials/tictactoe
    tutorials/logger
    tutorials/benchmark
+   tutorials/get_started
    tutorials/cheatsheet
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -147,3 +147,6 @@ mse
 gail
 airl
 ppo
+Jupyter
+Colab
+Colaboratory

--- a/docs/tutorials/get_started.rst
+++ b/docs/tutorials/get_started.rst
@@ -23,5 +23,5 @@ L5:  `Collector <https://colab.research.google.com/drive/1CvOTPiNXdSST04I75Wuyvy
 L6:  `Trainer <https://colab.research.google.com/drive/1qMsEiZZ8mh60ycbfoX-nYy6qMCnLkmZE?usp=sharing>`_
 ^^^^^^^^^^^^^^^^
 
-L7:  `TBD <https://github.com/thu-ml/tianshou/issues/349>`_
+L7:  `Experiment <https://colab.research.google.com/drive/1CieGncgbGCt2grx8Mzwb7YTmFB0AGJ0f?usp=sharing>`_
 ^^^^^^^^^^^^^^^^

--- a/docs/tutorials/get_started.rst
+++ b/docs/tutorials/get_started.rst
@@ -1,27 +1,13 @@
 Get Started with Jupyter Notebook
-======================================
+=================================
+
 In this tutorial, we will use Google Colaboratory to show you the most basic usages of common building blocks in Tianshou. You will be guided step by step to see how different modules in Tianshou collaborate with each other to conduct a classic DRL experiment (PPO algorithm for CartPole-v0 environment).
 
-L0:  `Overview <https://colab.research.google.com/drive/1yavOkfSTbyBD24-dyQzdETFN9YA7ioor?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L1:  `Batch <https://colab.research.google.com/drive/1uklagjDxYjJERS9gJvgbPnV1BtMuXvOR?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L2:  `Replay Buffer <https://colab.research.google.com/drive/1sfw-dDy02Gado-WuYlHAQsyWhZ33D1bd?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L3:  `Vectorized Environment <https://colab.research.google.com/drive/1ABk2BgjzvC4DZu1rDxGzd2Uqjo3FRLEy?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L4:  `Policy <https://colab.research.google.com/drive/1MhzYXtUEfnRrlAVSB3SR83r0HA5wds2i?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L5:  `Collector <https://colab.research.google.com/drive/1CvOTPiNXdSST04I75Wuyvy_hZ949zKHZ?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L6:  `Trainer <https://colab.research.google.com/drive/1qMsEiZZ8mh60ycbfoX-nYy6qMCnLkmZE?usp=sharing>`_
-^^^^^^^^^^^^^^^^
-
-L7:  `TBD <https://github.com/thu-ml/tianshou/issues/349>`_
-^^^^^^^^^^^^^^^^
+- L0:  `Overview <https://colab.research.google.com/drive/1yavOkfSTbyBD24-dyQzdETFN9YA7ioor?usp=sharing>`_
+- L1:  `Batch <https://colab.research.google.com/drive/1uklagjDxYjJERS9gJvgbPnV1BtMuXvOR?usp=sharing>`_
+- L2:  `Replay Buffer <https://colab.research.google.com/drive/1sfw-dDy02Gado-WuYlHAQsyWhZ33D1bd?usp=sharing>`_
+- L3:  `Vectorized Environment <https://colab.research.google.com/drive/1ABk2BgjzvC4DZu1rDxGzd2Uqjo3FRLEy?usp=sharing>`_
+- L4:  `Policy <https://colab.research.google.com/drive/1MhzYXtUEfnRrlAVSB3SR83r0HA5wds2i?usp=sharing>`_
+- L5:  `Collector <https://colab.research.google.com/drive/1CvOTPiNXdSST04I75Wuyvy_hZ949zKHZ?usp=sharing>`_
+- L6:  `Trainer <https://colab.research.google.com/drive/1qMsEiZZ8mh60ycbfoX-nYy6qMCnLkmZE?usp=sharing>`_
+- L7:  `TBD <https://github.com/thu-ml/tianshou/issues/349>`_

--- a/docs/tutorials/get_started.rst
+++ b/docs/tutorials/get_started.rst
@@ -1,0 +1,27 @@
+Get Started with Jupyter Notebook
+======================================
+In this tutorial, we will use Google Colaboratory to show you the most basic usages of common building blocks in Tianshou. You will be guided step by step to see how different modules in Tianshou collaborate with each other to conduct a classic DRL experiment (PPO algorithm for CartPole-v0 environment).
+
+L0:  `Overview <https://colab.research.google.com/drive/1yavOkfSTbyBD24-dyQzdETFN9YA7ioor?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L1:  `Batch <https://colab.research.google.com/drive/1uklagjDxYjJERS9gJvgbPnV1BtMuXvOR?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L2:  `Replay Buffer <https://colab.research.google.com/drive/1sfw-dDy02Gado-WuYlHAQsyWhZ33D1bd?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L3:  `Vectorized Environment <https://colab.research.google.com/drive/1ABk2BgjzvC4DZu1rDxGzd2Uqjo3FRLEy?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L4:  `Policy <https://colab.research.google.com/drive/1MhzYXtUEfnRrlAVSB3SR83r0HA5wds2i?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L5:  `Collector <https://colab.research.google.com/drive/1CvOTPiNXdSST04I75Wuyvy_hZ949zKHZ?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L6:  `Trainer <https://colab.research.google.com/drive/1qMsEiZZ8mh60ycbfoX-nYy6qMCnLkmZE?usp=sharing>`_
+^^^^^^^^^^^^^^^^
+
+L7:  `TBD <https://github.com/thu-ml/tianshou/issues/349>`_
+^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Jupyter notebook tutorials could help users get started with Tianshou. In this series of tutorials, I tried my best to explain the most basic usages of serveral core components in Tianshou. Compared to other tutorials hosted in documentation, this one care less about the implementing principles and more about getting started.

One thing I'm not sure about is where I should keep all those jupyter notebook files. For now they are in my Google Drive. I thought about hosting them in Tianshou's repo, but I don't want Tianshou get piled up with tutorials.