### PR TITLE
action_dim -> action_shape

### DIFF
--- a/tianshou/utils/net/discrete.py
+++ b/tianshou/utils/net/discrete.py
@@ -160,7 +160,7 @@ class ImplicitQuantileNetwork(Critic):
 
     :param preprocess_net: a self-defined preprocess_net which output a
         flattened hidden state.
-    :param int action_dim: the dimension of action space.
+    :param int action_shape: a sequence of int for the shape of action.
     :param hidden_sizes: a sequence of int for constructing the MLP after
         preprocess_net. Default to empty sequence (where the MLP now contains
         only a single linear layer).
@@ -254,7 +254,7 @@ class FullQuantileFunction(ImplicitQuantileNetwork):
 
     :param preprocess_net: a self-defined preprocess_net which output a
         flattened hidden state.
-    :param int action_dim: the dimension of action space.
+    :param int action_shape: a sequence of int for the shape of action.
     :param hidden_sizes: a sequence of int for constructing the MLP after
         preprocess_net. Default to empty sequence (where the MLP now contains
         only a single linear layer).


### PR DESCRIPTION
Noticed that in IQN and FQF there were some mismatches in the docstrings. Figured I would make a pull request to make it match. Causes an exception if using kwargs over args.

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [x] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [ ] If applicable, I have listed every items in this Pull Request below
