### PR TITLE
Support Basic MARL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ def get_extras_require() -> str:
             "doc8",
             "scipy",
             "pillow",
+            "supersuit",  # for padding pettingzoo
             "pettingzoo>=1.17",
             "pygame>=2.1.0",  # pettingzoo test cases pistonball
             "pymunk>=6.2.1",  # pettingzoo test cases pistonball

--- a/tianshou/env/pettingzoo_env.py
+++ b/tianshou/env/pettingzoo_env.py
@@ -78,6 +78,8 @@ class PettingZooEnv(AECEnv, ABC):
     def step(self, action: Any) -> Tuple[Dict, List[int], bool, Dict]:
         self.env.step(action)
         observation, rew, done, info = self.env.last()
+        if hasattr(self.env, "state"):
+            info["state"] = self.env.state()
         if isinstance(observation, dict) and 'action_mask' in observation:
             obs = {
                 'agent_id': self.env.agent_selection,

--- a/tianshou/env/pettingzoo_env.py
+++ b/tianshou/env/pettingzoo_env.py
@@ -76,11 +76,12 @@ class PettingZooEnv(AECEnv, ABC):
         observation = self.env.observe(self.env.agent_selection)
         if isinstance(observation, dict) and "action_mask" in observation:
             return {
-                "agent_id": self.env.agent_selection,
-                "obs": observation["observation"],
-                "mask": [
-                    True if obm == 1 else False for obm in observation["action_mask"]
-                ],
+                "agent_id":
+                self.env.agent_selection,
+                "obs":
+                observation["observation"],
+                "mask":
+                [True if obm == 1 else False for obm in observation["action_mask"]],
             }
         else:
             if isinstance(self.action_space, gym.spaces.Discrete):
@@ -99,11 +100,12 @@ class PettingZooEnv(AECEnv, ABC):
             info["state"] = self.env.state()
         if isinstance(observation, dict) and "action_mask" in observation:
             obs = {
-                "agent_id": self.env.agent_selection,
-                "obs": observation["observation"],
-                "mask": [
-                    True if obm == 1 else False for obm in observation["action_mask"]
-                ],
+                "agent_id":
+                self.env.agent_selection,
+                "obs":
+                observation["observation"],
+                "mask":
+                [True if obm == 1 else False for obm in observation["action_mask"]],
             }
         else:
             if isinstance(self.action_space, gym.spaces.Discrete):

--- a/tianshou/env/pettingzoo_env_ma_wrapper.py
+++ b/tianshou/env/pettingzoo_env_ma_wrapper.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import gym
 import numpy as np
+
 from tianshou.env import BaseVectorEnv, PettingZooEnv
 
 
@@ -22,8 +23,6 @@ class MAEnvWrapper(PettingZooEnv):
 
     def __len__(self) -> int:
         return self.num_agents
-
-
 
 
 def ma_venv_init(
@@ -82,15 +81,20 @@ def ma_venv_step(
             id[_i] = _id % self.env_num
     obs_stack, rew_stack, done_stack, info_stack = self.p_cls.step(self, action, id)
     for obs, info in zip(obs_stack, info_stack):
-        # self.env_num is the number of environments, while the env_num in collector is `the number of agents` * `the number of environments`
-        info["env_id"] = self.agent_idx[obs["agent_id"]] * self.env_num + info["env_id"]
+        # self.env_num is the number of environments,
+        # while the env_num in collector is
+        # `the number of agents` * `the number of environments`
+        info["env_id"] = (
+            self.agent_idx[obs["agent_id"]] * self.env_num +
+            info["env_id"])
     return obs_stack, rew_stack, done_stack, info_stack
 
 
 def get_MA_VectorEnv_cls(p_cls: Type[BaseVectorEnv]) -> Type[BaseVectorEnv]:
     """
     Get the class of Multi-Agent VectorEnv.
-    MAVectorEnv has the layout [(agent0, env0), (agent0, env1), ..., (agent1, env0), (agent1, env1), ...]
+    MAVectorEnv has the layout [(agent0, env0), (agent0, env1), ...,
+    (agent1, env0), (agent1, env1), ...]
     """
 
     def init_func(

--- a/tianshou/env/pettingzoo_env_ma_wrapper.py
+++ b/tianshou/env/pettingzoo_env_ma_wrapper.py
@@ -1,0 +1,115 @@
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+import gym
+import numpy as np
+from tianshou.env import BaseVectorEnv, PettingZooEnv
+
+
+class MAEnvWrapper(PettingZooEnv):
+    """wrap pettingzoo env to act as dummy env"""
+
+    def step(self, action: Any) -> Tuple[Dict, List[int], bool, Dict]:
+        """
+        :param Any action:
+        :return Tuple[Dict, List[int], bool, Dict]
+
+        Append env_id to the returned info.
+        """
+        obs, rew, done, info = super().step(action)
+        info["env_id"] = self.agent_idx[obs["agent_id"]]
+
+        return obs, rew, done, info
+
+    def __len__(self) -> int:
+        return self.num_agents
+
+
+
+
+def ma_venv_init(
+    self: BaseVectorEnv,
+    p_cls: Type[BaseVectorEnv],
+    env_fns: List[Callable[[], gym.Env]],
+    **kwargs: Any
+) -> None:
+    """add agents relevant attrs
+
+    :param BaseVectorEnv self
+    :param Type[BaseVectorEnv] p_cls
+    :param List[Callable[[], gym.Env]] env_fns
+    """
+    p_cls.__init__(self, env_fns, **kwargs)
+
+    self.p_cls = p_cls
+
+    agents = self.get_env_attr("agents", [0])[0]
+    agent_idx = self.get_env_attr("agent_idx", [0])[0]
+
+    self.agents = agents
+    self.agent_idx = agent_idx
+    self.agent_num = len(agent_idx)
+
+
+def ma_venv_len(self: BaseVectorEnv) -> int:
+    """
+    :param BaseVectorEnv self
+    :return int: num_agent * env_num
+    """
+    return sum(self.get_env_attr("num_agents"))
+
+
+def ma_venv_step(
+    self: BaseVectorEnv,
+    action: np.ndarray,
+    id: Optional[Union[int, List[int], np.ndarray]] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+
+    :param BaseVectorEnv self:
+    :param np.ndarray action:
+    :param Optional[Union[int, List[int], np.ndarray]] id: , defaults to None
+    :return Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+
+    ma_env_id is set to true env_id when taking step.
+
+    and (agent_id, env_id) is set back to ma_env_id in returned info
+    """
+    if id is not None:
+        if np.isscalar(id):
+            id = [id]
+        id = np.array(id)
+        for _i, _id in enumerate(id):
+            id[_i] = _id % self.env_num
+    obs_stack, rew_stack, done_stack, info_stack = self.p_cls.step(self, action, id)
+    for obs, info in zip(obs_stack, info_stack):
+        # self.env_num is the number of environments, while the env_num in collector is `the number of agents` * `the number of environments`
+        info["env_id"] = self.agent_idx[obs["agent_id"]] * self.env_num + info["env_id"]
+    return obs_stack, rew_stack, done_stack, info_stack
+
+
+def get_MA_VectorEnv_cls(p_cls: Type[BaseVectorEnv]) -> Type[BaseVectorEnv]:
+    """
+    Get the class of Multi-Agent VectorEnv.
+    MAVectorEnv has the layout [(agent0, env0), (agent0, env1), ..., (agent1, env0), (agent1, env1), ...]
+    """
+
+    def init_func(
+        self: BaseVectorEnv, env_fns: List[Callable[[], gym.Env]], **kwargs: Any
+    ) -> None:
+        ma_venv_init(self, p_cls, env_fns, **kwargs)
+
+    name = "MA" + p_cls.__name__
+
+    attr_dict = {"__init__": init_func, "__len__": ma_venv_len, "step": ma_venv_step}
+
+    return type(name, (p_cls,), attr_dict)
+
+
+def get_MA_VectorEnv(
+    p_cls: Type[BaseVectorEnv], env_fns: List[Callable[[], gym.Env]], **kwargs: Any
+) -> Type[BaseVectorEnv]:
+    """
+    Get an instance of Multi-Agent VectorEnv.
+    """
+
+    return get_MA_VectorEnv_cls(p_cls)(env_fns, **kwargs)

--- a/tianshou/env/pettingzoo_env_ma_wrapper.py
+++ b/tianshou/env/pettingzoo_env_ma_wrapper.py
@@ -26,10 +26,8 @@ class MAEnvWrapper(PettingZooEnv):
 
 
 def ma_venv_init(
-    self: BaseVectorEnv,
-    p_cls: Type[BaseVectorEnv],
-    env_fns: List[Callable[[], gym.Env]],
-    **kwargs: Any
+    self: BaseVectorEnv, p_cls: Type[BaseVectorEnv],
+    env_fns: List[Callable[[], gym.Env]], **kwargs: Any
 ) -> None:
     """add agents relevant attrs
 
@@ -39,14 +37,14 @@ def ma_venv_init(
     """
     p_cls.__init__(self, env_fns, **kwargs)
 
-    self.p_cls = p_cls
+    setattr(self, "p_lcs", p_cls)
 
     agents = self.get_env_attr("agents", [0])[0]
     agent_idx = self.get_env_attr("agent_idx", [0])[0]
 
-    self.agents = agents
-    self.agent_idx = agent_idx
-    self.agent_num = len(agent_idx)
+    setattr(self, "agents", agents)
+    setattr(self, "agent_idx", agent_idx)
+    setattr(self, "agent_num", len(agent_idx))
 
 
 def ma_venv_len(self: BaseVectorEnv) -> int:
@@ -74,7 +72,7 @@ def ma_venv_step(
     and (agent_id, env_id) is set back to ma_env_id in returned info
     """
     if id is not None:
-        if np.isscalar(id):
+        if isinstance(id, int):
             id = [id]
         id = np.array(id)
         for _i, _id in enumerate(id):
@@ -85,8 +83,8 @@ def ma_venv_step(
         # while the env_num in collector is
         # `the number of agents` * `the number of environments`
         info["env_id"] = (
-            self.agent_idx[obs["agent_id"]] * self.env_num +
-            info["env_id"])
+            self.agent_idx[obs["agent_id"]] * self.env_num + info["env_id"]
+        )
     return obs_stack, rew_stack, done_stack, info_stack
 
 
@@ -106,12 +104,12 @@ def get_MA_VectorEnv_cls(p_cls: Type[BaseVectorEnv]) -> Type[BaseVectorEnv]:
 
     attr_dict = {"__init__": init_func, "__len__": ma_venv_len, "step": ma_venv_step}
 
-    return type(name, (p_cls,), attr_dict)
+    return type(name, (p_cls, ), attr_dict)
 
 
 def get_MA_VectorEnv(
     p_cls: Type[BaseVectorEnv], env_fns: List[Callable[[], gym.Env]], **kwargs: Any
-) -> Type[BaseVectorEnv]:
+) -> BaseVectorEnv:
     """
     Get an instance of Multi-Agent VectorEnv.
     """


### PR DESCRIPTION
- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [x] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [ ] If applicable, I have mentioned the relevant/related issue(s)
- [ ] If applicable, I have listed every items in this Pull Request below

As I mentioned in #494, to support CTDE scheme or other schemes that need global information,  the returned `info` should contain more information.

By the way, I am trying to implement some basic MARL-communication algorithms based on tianshou. Inspired by https://github.com/thu-ml/tianshou/issues/399#issuecomment-881993755, I have the following design:
- [x] An multi-agent venv have `agent_num` agents and `env_num` envs should act as a venv with `agent_num` x `env_num` envs. `env_id` = `agent_num` x `env_num` + `env_num` should be contained in `info`.
- [x] Similar to AysncCollector, the `env_id` in `info` indicates which agents are taking actions.
- [ ] The MABuffer has `agent_num` x `env_num` buffers, the indices used for each agent should be the same.
- [ ] The MApolicy contains `agent_num` agents and the centralized module.

