### PR TITLE
fixed problem with tuple obs being confused with return tuple

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import sphinx_rtd_theme
-
 import tianshou
 
 # Get the version string

--- a/examples/atari/atari_c51.py
+++ b/examples/atari/atari_c51.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import C51
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import C51
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import C51Policy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/atari/atari_dqn.py
+++ b/examples/atari/atari_dqn.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import DQN
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import DQN
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import DQNPolicy
 from tianshou.policy.modelbased.icm import ICMPolicy

--- a/examples/atari/atari_fqf.py
+++ b/examples/atari/atari_fqf.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import DQN
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import DQN
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import FQFPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/atari/atari_iqn.py
+++ b/examples/atari/atari_iqn.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import DQN
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import DQN
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import IQNPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/atari/atari_ppo.py
+++ b/examples/atari/atari_ppo.py
@@ -5,11 +5,11 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import DQN
-from atari_wrapper import make_atari_env
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import DQN
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import ICMPolicy, PPOPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/atari/atari_qrdqn.py
+++ b/examples/atari/atari_qrdqn.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import QRDQN
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import QRDQN
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import QRDQNPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/atari/atari_rainbow.py
+++ b/examples/atari/atari_rainbow.py
@@ -5,10 +5,10 @@ import pprint
 
 import numpy as np
 import torch
-from atari_network import Rainbow
-from atari_wrapper import make_atari_env
 from torch.utils.tensorboard import SummaryWriter
 
+from atari_network import Rainbow
+from atari_wrapper import make_atari_env
 from tianshou.data import Collector, PrioritizedVectorReplayBuffer, VectorReplayBuffer
 from tianshou.policy import RainbowPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/atari/atari_wrapper.py
+++ b/examples/atari/atari_wrapper.py
@@ -8,12 +8,12 @@ import cv2
 import gym
 import numpy as np
 
+from tianshou.env import ShmemVectorEnv
+
 try:
     import envpool
 except ImportError:
     envpool = None
-
-from tianshou.env import ShmemVectorEnv
 
 
 class NoopResetEnv(gym.Wrapper):

--- a/examples/inverse/irl_gail.py
+++ b/examples/inverse/irl_gail.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import pprint
 
-import d4rl
 import gym
 import numpy as np
 import torch
@@ -14,6 +13,7 @@ from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+import d4rl
 from tianshou.data import Batch, Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.env import SubprocVectorEnv
 from tianshou.policy import GAILPolicy

--- a/examples/mujoco/analysis.py
+++ b/examples/mujoco/analysis.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 import numpy as np
 from tabulate import tabulate
+
 from tools import csv2numpy, find_all_files, group_files
 
 

--- a/examples/mujoco/mujoco_a2c.py
+++ b/examples/mujoco/mujoco_a2c.py
@@ -7,12 +7,12 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch import nn
 from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import A2CPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/mujoco/mujoco_ddpg.py
+++ b/examples/mujoco/mujoco_ddpg.py
@@ -7,9 +7,9 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.exploration import GaussianNoise
 from tianshou.policy import DDPGPolicy

--- a/examples/mujoco/mujoco_env.py
+++ b/examples/mujoco/mujoco_env.py
@@ -1,13 +1,13 @@
 import warnings
 
+import gym
+
+from tianshou.env import ShmemVectorEnv, VectorEnvNormObs
+
 try:
     import envpool
 except ImportError:
     envpool = None
-
-import gym
-
-from tianshou.env import ShmemVectorEnv, VectorEnvNormObs
 
 
 def make_mujoco_env(task, seed, training_num, test_num, obs_norm):

--- a/examples/mujoco/mujoco_npg.py
+++ b/examples/mujoco/mujoco_npg.py
@@ -7,12 +7,12 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch import nn
 from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import NPGPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/mujoco/mujoco_ppo.py
+++ b/examples/mujoco/mujoco_ppo.py
@@ -7,12 +7,12 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch import nn
 from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import PPOPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/mujoco/mujoco_redq.py
+++ b/examples/mujoco/mujoco_redq.py
@@ -7,9 +7,9 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import REDQPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/mujoco/mujoco_reinforce.py
+++ b/examples/mujoco/mujoco_reinforce.py
@@ -7,12 +7,12 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch import nn
 from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import PGPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/mujoco/mujoco_sac.py
+++ b/examples/mujoco/mujoco_sac.py
@@ -7,9 +7,9 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import SACPolicy
 from tianshou.trainer import offpolicy_trainer

--- a/examples/mujoco/mujoco_td3.py
+++ b/examples/mujoco/mujoco_td3.py
@@ -7,9 +7,9 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.exploration import GaussianNoise
 from tianshou.policy import TD3Policy

--- a/examples/mujoco/mujoco_trpo.py
+++ b/examples/mujoco/mujoco_trpo.py
@@ -7,12 +7,12 @@ import pprint
 
 import numpy as np
 import torch
-from mujoco_env import make_mujoco_env
 from torch import nn
 from torch.distributions import Independent, Normal
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from mujoco_env import make_mujoco_env
 from tianshou.data import Collector, ReplayBuffer, VectorReplayBuffer
 from tianshou.policy import TRPOPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/examples/mujoco/plotter.py
+++ b/examples/mujoco/plotter.py
@@ -7,6 +7,7 @@ import re
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
+
 from tools import csv2numpy, find_all_files, group_files
 
 

--- a/examples/offline/utils.py
+++ b/examples/offline/utils.py
@@ -1,7 +1,7 @@
-import d4rl
 import gym
 import h5py
 
+import d4rl
 from tianshou.data import ReplayBuffer
 
 

--- a/examples/vizdoom/env.py
+++ b/examples/vizdoom/env.py
@@ -3,6 +3,7 @@ import os
 import cv2
 import gym
 import numpy as np
+
 import vizdoom as vzd
 
 

--- a/examples/vizdoom/replay.py
+++ b/examples/vizdoom/replay.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 import tqdm
+
 import vizdoom as vzd
 
 

--- a/examples/vizdoom/vizdoom_c51.py
+++ b/examples/vizdoom/vizdoom_c51.py
@@ -4,10 +4,10 @@ import pprint
 
 import numpy as np
 import torch
-from env import Env
-from network import C51
 from torch.utils.tensorboard import SummaryWriter
 
+from env import Env
+from network import C51
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import ShmemVectorEnv
 from tianshou.policy import C51Policy

--- a/examples/vizdoom/vizdoom_ppo.py
+++ b/examples/vizdoom/vizdoom_ppo.py
@@ -4,11 +4,11 @@ import pprint
 
 import numpy as np
 import torch
-from env import Env
-from network import DQN
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
+from env import Env
+from network import DQN
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import ShmemVectorEnv
 from tianshou.policy import ICMPolicy, PPOPolicy

--- a/test/3rd_party/test_nni.py
+++ b/test/3rd_party/test_nni.py
@@ -5,19 +5,17 @@ import threading
 import time
 from typing import List, Union
 
+import torch
+import torch.nn.functional as F
+
 import nni.retiarii.execution.api
 import nni.retiarii.nn.pytorch as nn
 import nni.retiarii.strategy as strategy
-import torch
-import torch.nn.functional as F
 from nni.retiarii import Model
 from nni.retiarii.converter import convert_to_graph
 from nni.retiarii.execution import wait_models
 from nni.retiarii.execution.interface import (
-    AbstractExecutionEngine,
-    AbstractGraphListener,
-    MetricData,
-    WorkerInfo,
+    AbstractExecutionEngine, AbstractGraphListener, MetricData, WorkerInfo
 )
 from nni.retiarii.graph import DebugEvaluator, ModelStatus
 from nni.retiarii.nn.pytorch.mutator import process_inline_mutation

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -9,13 +9,8 @@ import pytest
 import torch
 
 from tianshou.data import (
-    Batch,
-    CachedReplayBuffer,
-    PrioritizedReplayBuffer,
-    PrioritizedVectorReplayBuffer,
-    ReplayBuffer,
-    SegmentTree,
-    VectorReplayBuffer,
+    Batch, CachedReplayBuffer, PrioritizedReplayBuffer, PrioritizedVectorReplayBuffer,
+    ReplayBuffer, SegmentTree, VectorReplayBuffer
 )
 from tianshou.data.utils.converter import to_hdf5
 

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -4,13 +4,8 @@ import tqdm
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.data import (
-    AsyncCollector,
-    Batch,
-    CachedReplayBuffer,
-    Collector,
-    PrioritizedReplayBuffer,
-    ReplayBuffer,
-    VectorReplayBuffer,
+    AsyncCollector, Batch, CachedReplayBuffer, Collector, PrioritizedReplayBuffer,
+    ReplayBuffer, VectorReplayBuffer
 )
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv
 from tianshou.policy import BasePolicy

--- a/test/base/test_env.py
+++ b/test/base/test_env.py
@@ -7,11 +7,7 @@ from gym.spaces.discrete import Discrete
 
 from tianshou.data import Batch
 from tianshou.env import (
-    DummyVectorEnv,
-    RayVectorEnv,
-    ShmemVectorEnv,
-    SubprocVectorEnv,
-    VectorEnvNormObs,
+    DummyVectorEnv, RayVectorEnv, ShmemVectorEnv, SubprocVectorEnv, VectorEnvNormObs
 )
 from tianshou.utils import RunningMeanStd
 

--- a/test/continuous/test_sac_with_il.py
+++ b/test/continuous/test_sac_with_il.py
@@ -2,11 +2,6 @@ import argparse
 import os
 import sys
 
-try:
-    import envpool
-except ImportError:
-    envpool = None
-
 import numpy as np
 import pytest
 import torch
@@ -18,6 +13,11 @@ from tianshou.trainer import offpolicy_trainer
 from tianshou.utils import TensorboardLogger
 from tianshou.utils.net.common import Net
 from tianshou.utils.net.continuous import Actor, ActorProb, Critic
+
+try:
+    import envpool
+except ImportError:
+    envpool = None
 
 
 def get_args():

--- a/test/discrete/test_a2c_with_il.py
+++ b/test/discrete/test_a2c_with_il.py
@@ -2,12 +2,12 @@ import argparse
 import os
 import pprint
 
-import envpool
 import gym
 import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
+import envpool
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import A2CPolicy, ImitationPolicy
 from tianshou.trainer import offpolicy_trainer, onpolicy_trainer

--- a/test/modelbased/test_psrl.py
+++ b/test/modelbased/test_psrl.py
@@ -2,11 +2,11 @@ import argparse
 import os
 import pprint
 
-import envpool
 import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
+import envpool
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.policy import PSRLPolicy
 from tianshou.trainer import onpolicy_trainer

--- a/test/pettingzoo/pistonball.py
+++ b/test/pettingzoo/pistonball.py
@@ -4,10 +4,10 @@ from typing import List, Optional, Tuple
 
 import gym
 import numpy as np
-import pettingzoo.butterfly.pistonball_v6 as pistonball_v6
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
+import pettingzoo.butterfly.pistonball_v6 as pistonball_v6
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv
 from tianshou.env.pettingzoo_env import PettingZooEnv

--- a/test/pettingzoo/pistonball_continuous.py
+++ b/test/pettingzoo/pistonball_continuous.py
@@ -4,12 +4,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import gym
 import numpy as np
-import pettingzoo.butterfly.pistonball_v6 as pistonball_v6
 import torch
 import torch.nn as nn
 from torch.distributions import Independent, Normal
 from torch.utils.tensorboard import SummaryWriter
 
+import pettingzoo.butterfly.pistonball_v6 as pistonball_v6
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv
 from tianshou.env.pettingzoo_env import PettingZooEnv

--- a/test/pettingzoo/test_pistonball_continuous.py
+++ b/test/pettingzoo/test_pistonball_continuous.py
@@ -1,6 +1,7 @@
 import pprint
 
 import pytest
+
 from pistonball_continuous import get_args, train_agent, watch
 
 

--- a/test/pettingzoo/tic_tac_toe.py
+++ b/test/pettingzoo/tic_tac_toe.py
@@ -6,17 +6,14 @@ from typing import Optional, Tuple
 import gym
 import numpy as np
 import torch
-from pettingzoo.classic import tictactoe_v3
 from torch.utils.tensorboard import SummaryWriter
 
+from pettingzoo.classic import tictactoe_v3
 from tianshou.data import Collector, VectorReplayBuffer
 from tianshou.env import DummyVectorEnv
 from tianshou.env.pettingzoo_env import PettingZooEnv
 from tianshou.policy import (
-    BasePolicy,
-    DQNPolicy,
-    MultiAgentPolicyManager,
-    RandomPolicy,
+    BasePolicy, DQNPolicy, MultiAgentPolicyManager, RandomPolicy
 )
 from tianshou.trainer import offpolicy_trainer
 from tianshou.utils import TensorboardLogger

--- a/tianshou/data/buffer/vecbuf.py
+++ b/tianshou/data/buffer/vecbuf.py
@@ -3,10 +3,8 @@ from typing import Any
 import numpy as np
 
 from tianshou.data import (
-    PrioritizedReplayBuffer,
-    PrioritizedReplayBufferManager,
-    ReplayBuffer,
-    ReplayBufferManager,
+    PrioritizedReplayBuffer, PrioritizedReplayBufferManager, ReplayBuffer,
+    ReplayBufferManager
 )
 
 

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -7,12 +7,8 @@ import numpy as np
 import torch
 
 from tianshou.data import (
-    Batch,
-    CachedReplayBuffer,
-    ReplayBuffer,
-    ReplayBufferManager,
-    VectorReplayBuffer,
-    to_numpy,
+    Batch, CachedReplayBuffer, ReplayBuffer, ReplayBufferManager, VectorReplayBuffer,
+    to_numpy
 )
 from tianshou.data.batch import _alloc_by_keys_diff
 from tianshou.env import BaseVectorEnv, DummyVectorEnv

--- a/tianshou/env/pettingzoo_env.py
+++ b/tianshou/env/pettingzoo_env.py
@@ -2,6 +2,7 @@ from abc import ABC
 from typing import Any, Dict, List, Tuple
 
 import gym.spaces
+
 from pettingzoo.utils.env import AECEnv
 from pettingzoo.utils.wrappers import BaseWrapper
 

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -4,10 +4,7 @@ import gym
 import numpy as np
 
 from tianshou.env.worker import (
-    DummyEnvWorker,
-    EnvWorker,
-    RayEnvWorker,
-    SubprocEnvWorker,
+    DummyEnvWorker, EnvWorker, RayEnvWorker, SubprocEnvWorker
 )
 
 GYM_RESERVED_KEYS = [

--- a/tianshou/env/worker/base.py
+++ b/tianshou/env/worker/base.py
@@ -16,6 +16,7 @@ class EnvWorker(ABC):
         self.result: Union[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
                            np.ndarray]
         self.action_space = self.get_env_attr("action_space")  # noqa: B009
+        self.observation_space = self.get_env_attr("observation_space")  # noqa: B009
         self.is_reset = False
 
     @abstractmethod

--- a/tianshou/env/worker/subproc.py
+++ b/tianshou/env/worker/subproc.py
@@ -193,7 +193,7 @@ class SubprocEnvWorker(EnvWorker):
         self
     ) -> Union[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray]:
         result = self.parent_remote.recv()
-        if isinstance(result, tuple):
+        if isinstance(result, tuple) and len(result)==4:
             obs, rew, done, info = result
             if self.share_memory:
                 obs = self._decode_obs()

--- a/tianshou/env/worker/subproc.py
+++ b/tianshou/env/worker/subproc.py
@@ -193,7 +193,7 @@ class SubprocEnvWorker(EnvWorker):
         self
     ) -> Union[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray]:
         result = self.parent_remote.recv()
-        if isinstance(result, tuple) and len(result) == 4:
+        if isinstance(result, tuple) and self.observation_space.contains(result[0]) and isinstance(result[1],float) and isinstance(result[2],bool) and isinstance(result[3],dict):
             obs, rew, done, info = result
             if self.share_memory:
                 obs = self._decode_obs()

--- a/tianshou/env/worker/subproc.py
+++ b/tianshou/env/worker/subproc.py
@@ -193,7 +193,7 @@ class SubprocEnvWorker(EnvWorker):
         self
     ) -> Union[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray]:
         result = self.parent_remote.recv()
-        if isinstance(result, tuple) and len(result)==4:
+        if isinstance(result, tuple) and len(result) == 4:
             obs, rew, done, info = result
             if self.share_memory:
                 obs = self._decode_obs()

--- a/tianshou/utils/net/common.py
+++ b/tianshou/utils/net/common.py
@@ -1,13 +1,5 @@
 from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    no_type_check,
+    Any, Dict, List, Optional, Sequence, Tuple, Type, Union, no_type_check
 )
 
 import numpy as np


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [ ] If applicable, I have mentioned the relevant/related issue(s)
- [ ] If applicable, I have listed every items in this Pull Request below

Envs with tuple observations failed when reset because the code thought that reset was returning a tuple of obs, return, done, info, so I added a better type check. I also made the continuous Critic work with structured obs (like tuples)