### PR TITLE
Fix exception with watching pistonball environments

### DIFF
--- a/test/pettingzoo/pistonball.py
+++ b/test/pettingzoo/pistonball.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import warnings
 from typing import List, Optional, Tuple
 
 import gym
@@ -177,6 +178,12 @@ def watch(
     args: argparse.Namespace = get_args(), policy: Optional[BasePolicy] = None
 ) -> None:
     env = DummyVectorEnv([get_env])
+    if not policy:
+        warnings.warn(
+            "watching random agents, as loading pre-trained policies is "
+            "currently not supported"
+        )
+        policy, _, _ = get_agents(args)
     policy.eval()
     [agent.set_eps(args.eps_test) for agent in policy.policies.values()]
     collector = Collector(policy, env, exploration_noise=True)

--- a/test/pettingzoo/pistonball_continuous.py
+++ b/test/pettingzoo/pistonball_continuous.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import gym
@@ -269,6 +270,12 @@ def watch(
     args: argparse.Namespace = get_args(), policy: Optional[BasePolicy] = None
 ) -> None:
     env = DummyVectorEnv([get_env])
+    if not policy:
+        warnings.warn(
+            "watching random agents, as loading pre-trained policies is "
+            "currently not supported"
+        )
+        policy, _, _ = get_agents(args)
     policy.eval()
     collector = Collector(policy, env)
     result = collector.collect(n_episode=1, render=args.render)


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below

fixes https://github.com/thu-ml/tianshou/issues/661 for now. I will also look into how we can save and load multiple agents for pettingzoo environments.