### PR TITLE
Remove test_fn and train_fn as they are not used in PPO PistonBall example for PettingZoo

### DIFF
--- a/test/pettingzoo/pistonball_continuous.py
+++ b/test/pettingzoo/pistonball_continuous.py
@@ -237,12 +237,6 @@ def train_agent(
     def stop_fn(mean_rewards):
         return False
 
-    def train_fn(epoch, env_step):
-        [agent.set_eps(args.eps_train) for agent in policy.policies.values()]
-
-    def test_fn(epoch, env_step):
-        [agent.set_eps(args.eps_test) for agent in policy.policies.values()]
-
     def reward_metric(rews):
         return rews[:, 0]
 


### PR DESCRIPTION
Specifically, BasePolicy.set_eps seems to be a remnant from using DQN in other examples.

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [x] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below


* Removed unused functions (test_fn and train_fn) from the pettingzoo example with PistonBall. These functions use set_eps which is not available for PPO and is not even called once in the file.