### PR TITLE
Update venvs.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,26 +10,26 @@ repos:
   #       args: [--config-file=setup.cfg, tianshou]
 
   - repo: https://github.com/google/yapf
-    rev: v0.32.0
+    rev: v0.33.0
     hooks:
       - id: yapf
         args: [-r, -i]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: [--config=setup.cfg, --count, --show-source, --statistics]
         additional_dependencies: ["flake8_bugbear"]
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         exclude: ^(test/)|(docs/)|(examples/)|(setup.py)

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -337,6 +337,8 @@ class BaseVectorEnv(object):
         id = self._wrap_id(id)
         if not self.is_async:
             assert len(action) == len(id)
+            if len(action.shape) == 1:
+                action = np.expand_dims(action, -1)
             for i, j in enumerate(id):
                 self.workers[j].send(action[i])
             result = []
@@ -348,6 +350,8 @@ class BaseVectorEnv(object):
             if action is not None:
                 self._assert_id(id)
                 assert len(action) == len(id)
+                if len(action.shape) == 1:
+                    action = np.expand_dims(action, -1)
                 for act, env_id in zip(action, id):
                     self.workers[env_id].send(act)
                     self.waiting_conn.append(self.workers[env_id])

--- a/tianshou/env/venvs.py
+++ b/tianshou/env/venvs.py
@@ -337,7 +337,7 @@ class BaseVectorEnv(object):
         id = self._wrap_id(id)
         if not self.is_async:
             assert len(action) == len(id)
-            if len(action.shape) == 1:
+            if isinstance(action, np.ndarray) and len(action.shape) == 1:
                 action = np.expand_dims(action, -1)
             for i, j in enumerate(id):
                 self.workers[j].send(action[i])
@@ -350,7 +350,7 @@ class BaseVectorEnv(object):
             if action is not None:
                 self._assert_id(id)
                 assert len(action) == len(id)
-                if len(action.shape) == 1:
+                if isinstance(action, np.ndarray) and len(action.shape) == 1:
                     action = np.expand_dims(action, -1)
                 for act, env_id in zip(action, id):
                     self.workers[env_id].send(act)


### PR DESCRIPTION
fix bug when action shape is 1D in eval.


For example:

```python
import gymnasium as gym
import numpy as np
import torch

from tianshou.data import Collector, VectorReplayBuffer
from tianshou.env import DummyVectorEnv
from tianshou.policy import PPOPolicy
from tianshou.trainer import onpolicy_trainer
from tianshou.utils.net.common import ActorCritic, Net
from tianshou.utils.net.discrete import Actor, Critic

import warnings
warnings.filterwarnings('ignore')

device = 'cuda' if torch.cuda.is_available() else 'cpu'

# environments
env = gym.make('MountainCarContinuous-v0')
train_envs = DummyVectorEnv([lambda: gym.make('MountainCarContinuous-v0') for _ in range(2)])
test_envs = DummyVectorEnv([lambda: gym.make('MountainCarContinuous-v0') for _ in range(1)])

# model & optimizer
net = Net(env.observation_space.shape, hidden_sizes=[64, 64], device=device)
actor = Actor(net, env.action_space.shape, device=device).to(device)
critic = Critic(net, device=device).to(device)
actor_critic = ActorCritic(actor, critic)
optim = torch.optim.Adam(actor_critic.parameters(), lr=0.0003)

# PPO policy
dist = torch.distributions.ContinuousBernoulli
policy = PPOPolicy(actor, critic, optim, dist, action_space=env.action_space, deterministic_eval=True)
        
          
# collector
train_collector = Collector(policy, train_envs, VectorReplayBuffer(20000, len(train_envs)))
test_collector = Collector(policy, test_envs)

# trainer
result = onpolicy_trainer(
    policy,
    train_collector,
    test_collector,
    max_epoch=10,
    step_per_epoch=50000,
    repeat_per_collect=10,
    episode_per_test=10,
    batch_size=256,
    step_per_collect=2000,
    stop_fn=lambda mean_reward: mean_reward >= 195,
)
print(result)
```


Error
```bash
Traceback (most recent call last):
  File "test.py", line 39, in <module>
    result = onpolicy_trainer(
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/trainer/onpolicy.py", line 150, in onpolicy_trainer
    return OnpolicyTrainer(*args, **kwargs).run()
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/trainer/base.py", line 441, in run
    deque(self, maxlen=0)  # feed the entire iterator into a zero-length deque
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/trainer/base.py", line 252, in __iter__
    self.reset()
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/trainer/base.py", line 237, in reset
    test_result = test_episode(
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/trainer/utils.py", line 27, in test_episode
    result = collector.collect(n_episode=n_episode)
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/data/collector.py", line 295, in collect
    obs_next, rew, terminated, truncated, info = self.env.step(
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/env/venvs.py", line 347, in step
    self.workers[j].send(action[i])
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/tianshou/env/worker/dummy.py", line 38, in send
    self.result = self.env.step(action)  # type: ignore
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/gymnasium/wrappers/time_limit.py", line 57, in step
    observation, reward, terminated, truncated, info = self.env.step(action)
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/gymnasium/wrappers/order_enforcing.py", line 56, in step
    return self.env.step(action)
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/gymnasium/wrappers/env_checker.py", line 47, in step
    return env_step_passive_checker(self.env, action)
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/gymnasium/utils/passive_env_checker.py", line 237, in env_step_passive_checker
    result = env.step(action)
  File "/home/yimin/anaconda3/envs/py38/lib/python3.8/site-packages/gymnasium/envs/classic_control/continuous_mountain_car.py", line 150, in step
    action = action[0] 
IndexError: invalid index to scalar variable.
```

- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [ ] If applicable, I have mentioned the relevant/related issue(s)
- [ ] If applicable, I have listed every items in this Pull Request below
