### PR TITLE
Make monitor_gym configurable in WandbLogger.

### DIFF
--- a/tianshou/utils/logger/wandb.py
+++ b/tianshou/utils/logger/wandb.py
@@ -54,6 +54,7 @@ class WandbLogger(BaseLogger):
         entity: Optional[str] = None,
         run_id: Optional[str] = None,
         config: Optional[argparse.Namespace] = None,
+        monitor_gym: bool = True,
     ) -> None:
         super().__init__(train_interval, test_interval, update_interval)
         self.last_save_step = -1
@@ -70,7 +71,7 @@ class WandbLogger(BaseLogger):
             resume="allow",
             entity=entity,
             sync_tensorboard=True,
-            monitor_gym=True,
+            monitor_gym=monitor_gym,
             config=config,  # type: ignore
         ) if not wandb.run else wandb.run
         self.wandb_run._label(repo="tianshou")  # type: ignore


### PR DESCRIPTION
- [x] I have marked all applicable categories:
    + [x] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below

At the moment, WandbLogger is always using wandb.init with monitor_gym = True.
This fails when OpenAI's gym is not installed, which doesn't make sense after the transition to Gymnasium.

I am using Tianshou with non-standard RL environment, which adhere to Gymnasium API, and the current code is throwing exceptions.

I suggest to make it a controllable parameter. I left the default value to True (to make it functionally the same for people using gym). It may also make sense to change the default to False.