### PR TITLE
Fixed the mapolicy train issue

### DIFF
--- a/tianshou/policy/multiagent/mapolicy.py
+++ b/tianshou/policy/multiagent/mapolicy.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import numpy as np
 
@@ -230,11 +230,11 @@ class MultiAgentPolicyManager(BasePolicy):
                 for k, v in out.items():
                     results[agent_id + "/" + k] = v
         return results
-    
-    # Bug Fix. Need a train method that set all sub-policies to train mode.
-    # No need for a similar eval function, as eval internally uses the train function. 
-    def train(self, mode: bool = True) -> "MultiAgentPolicyManager":
+
+    # Need a train method that set all sub-policies to train mode.
+    # No need for a similar eval function, as eval internally uses the train function.
+    def train(self, mode: bool = True) -> Self:
         """Set each internal policy in training mode."""
-        for agent_id, policy in self.policies.items():
+        for policy in self.policies.values():
             policy.train(mode)
         return self

--- a/tianshou/policy/multiagent/mapolicy.py
+++ b/tianshou/policy/multiagent/mapolicy.py
@@ -234,8 +234,7 @@ class MultiAgentPolicyManager(BasePolicy):
     # Bug Fix. Need a train method that set all sub-policies to train mode.
     # No need for a similar eval function, as eval internally uses the train function. 
     def train(self, mode: bool = True):
-        r"""Sets each internal policy in training mode.
-        """
+        """Set each internal policy in training mode."""
         for agent_id, policy in self.policies.items():
             policy.train(mode)
         return self

--- a/tianshou/policy/multiagent/mapolicy.py
+++ b/tianshou/policy/multiagent/mapolicy.py
@@ -233,7 +233,7 @@ class MultiAgentPolicyManager(BasePolicy):
     
     # Bug Fix. Need a train method that set all sub-policies to train mode.
     # No need for a similar eval function, as eval internally uses the train function. 
-    def train(self, mode: bool = True):
+    def train(self, mode: bool = True) -> "MultiAgentPolicyManager":
         """Set each internal policy in training mode."""
         for agent_id, policy in self.policies.items():
             policy.train(mode)

--- a/tianshou/policy/multiagent/mapolicy.py
+++ b/tianshou/policy/multiagent/mapolicy.py
@@ -230,3 +230,12 @@ class MultiAgentPolicyManager(BasePolicy):
                 for k, v in out.items():
                     results[agent_id + "/" + k] = v
         return results
+    
+    # Bug Fix. Need a train method that set all sub-policies to train mode.
+    # No need for a similar eval function, as eval internally uses the train function. 
+    def train(self, mode: bool = True):
+        r"""Sets each internal policy in training mode.
+        """
+        for agent_id, policy in self.policies.items():
+            policy.train(mode)
+        return self


### PR DESCRIPTION
The trained MARL policies were not performing as expected because the parent class (MultiAgentPolicyManager) needed a train function.

- [x] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [x] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make commit-checks` (**required**)
- [x] If applicable, I have mentioned the relevant/related issue(s)
- [x] If applicable, I have listed every items in this Pull Request below

Fixes thu-ml/tianshou#967