### PR TITLE
Fix/add watch env with obs rms

### DIFF
--- a/examples/mujoco/mujoco_env.py
+++ b/examples/mujoco/mujoco_env.py
@@ -1,10 +1,11 @@
 import logging
 import pickle
 
-from tianshou.env import VectorEnvNormObs
+from tianshou.env import BaseVectorEnv, VectorEnvNormObs
 from tianshou.highlevel.env import (
     ContinuousEnvironments,
     EnvFactoryRegistered,
+    EnvMode,
     EnvPoolFactory,
     VectorEnvType,
 )
@@ -56,6 +57,8 @@ class MujocoEnvObsRmsPersistence(Persistence):
             obs_rms = pickle.load(f)
         world.envs.train_envs.set_obs_rms(obs_rms)
         world.envs.test_envs.set_obs_rms(obs_rms)
+        if world.watch_env is not None:
+            world.watch_env.set_obs_rms(obs_rms)
 
 
 class MujocoEnvFactory(EnvFactoryRegistered):
@@ -68,14 +71,24 @@ class MujocoEnvFactory(EnvFactoryRegistered):
         )
         self.obs_norm = obs_norm
 
+    def create_venv(self, num_envs: int, mode: EnvMode) -> BaseVectorEnv:
+        """Create vectorized environments.
+
+        :param num_envs: the number of environments
+        :param mode: the mode for which to create
+        :return: the vectorized environments
+        """
+        env = super().create_venv(num_envs, mode)
+        if self.obs_norm:
+            env = VectorEnvNormObs(env, update_obs_rms=mode == EnvMode.TRAIN)
+        return env
+
     def create_envs(self, num_training_envs: int, num_test_envs: int) -> ContinuousEnvironments:
         envs = super().create_envs(num_training_envs, num_test_envs)
         assert isinstance(envs, ContinuousEnvironments)
 
         # obs norm wrapper
         if self.obs_norm:
-            envs.train_envs = VectorEnvNormObs(envs.train_envs)
-            envs.test_envs = VectorEnvNormObs(envs.test_envs, update_obs_rms=False)
             envs.test_envs.set_obs_rms(envs.train_envs.get_obs_rms())
             envs.set_persistence(MujocoEnvObsRmsPersistence())
 

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -291,6 +291,7 @@ class Experiment(ToStringMixin):
 
             # watch agent performance
             if self.config.watch:
+                assert envs.watch_env is not None
                 log.info("Watching agent performance")
                 self._watch_agent(
                     self.config.watch_num_episodes,

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -27,7 +27,7 @@ from tianshou.highlevel.agent import (
     TRPOAgentFactory,
 )
 from tianshou.highlevel.config import SamplingConfig
-from tianshou.highlevel.env import EnvFactory, EnvMode
+from tianshou.highlevel.env import EnvFactory
 from tianshou.highlevel.logger import LoggerFactory, LoggerFactoryDefault, TLogger
 from tianshou.highlevel.module.actor import (
     ActorFactory,
@@ -223,9 +223,8 @@ class Experiment(ToStringMixin):
             envs = self.env_factory.create_envs(
                 self.sampling_config.num_train_envs,
                 self.sampling_config.num_test_envs,
+                create_watch_env=self.config.watch,
             )
-            if self.config.watch:
-                watch_env = self.env_factory.create_venv(1, EnvMode.WATCH)
             log.info(f"Created {envs}")
 
             # initialize persistence
@@ -265,7 +264,6 @@ class Experiment(ToStringMixin):
             # create context object with all relevant instances (except trainer; added later)
             world = World(
                 envs=envs,
-                watch_env=watch_env if self.config.watch else None,
                 policy=policy,
                 train_collector=train_collector,
                 test_collector=test_collector,
@@ -297,7 +295,7 @@ class Experiment(ToStringMixin):
                 self._watch_agent(
                     self.config.watch_num_episodes,
                     policy,
-                    watch_env,
+                    envs.watch_env,
                     self.config.watch_render,
                 )
 

--- a/tianshou/highlevel/world.py
+++ b/tianshou/highlevel/world.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from tianshou.data import Collector
-    from tianshou.env import BaseVectorEnv
     from tianshou.highlevel.env import Environments
     from tianshou.highlevel.logger import TLogger
     from tianshou.policy import BasePolicy
@@ -23,7 +22,6 @@ class World:
     persist_directory: str
     restore_directory: str | None
     trainer: Optional["BaseTrainer"] = None
-    watch_env: Optional["BaseVectorEnv"] = None
 
     def persist_path(self, filename: str) -> str:
         return os.path.join(self.persist_directory, filename)

--- a/tianshou/highlevel/world.py
+++ b/tianshou/highlevel/world.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from tianshou.data import Collector
+    from tianshou.env import BaseVectorEnv
     from tianshou.highlevel.env import Environments
     from tianshou.highlevel.logger import TLogger
     from tianshou.policy import BasePolicy
@@ -22,6 +23,7 @@ class World:
     persist_directory: str
     restore_directory: str | None
     trainer: Optional["BaseTrainer"] = None
+    watch_env: Optional["BaseVectorEnv"] = None
 
     def persist_path(self, filename: str) -> str:
         return os.path.join(self.persist_directory, filename)


### PR DESCRIPTION
- [ ] I have added the correct label(s) to this Pull Request or linked the relevant issue(s)
- [ ] I have provided a description of the changes in this Pull Request
- [ ] I have added documentation for my changes
- [ ] If applicable, I have added tests to cover my changes.
- [x] I have reformatted the code using `poe format` 
- [x] I have checked style and types with `poe lint` and `poe type-check`
- [ ] (Optional) I ran tests locally with `poe test` 
(or a subset of them with `poe test-reduced`) ,and they pass
- [ ] (Optional) I have tested that documentation builds correctly with `poe doc-build`

Currently, the high-level experiment does not set the obs_rms property for watching a policy learned on environments using observation normalization. This PR adds a "watch environment" to the high-level experiment and sets the obs_rms property based on the train_env.