### PR TITLE
Unified build method for HL experiment

### DIFF
--- a/examples/atari/atari_dqn_hl.py
+++ b/examples/atari/atari_dqn_hl.py
@@ -103,7 +103,7 @@ def main(
             ),
         )
 
-    experiment = builder.build()
+    experiment = builder.build()[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/atari/atari_iqn_hl.py
+++ b/examples/atari/atari_iqn_hl.py
@@ -95,7 +95,7 @@ def main(
         .with_epoch_test_callback(EpochTestCallbackDQNSetEps(eps_test))
         .with_epoch_stop_callback(AtariEpochStopCallback(task))
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/atari/atari_ppo_hl.py
+++ b/examples/atari/atari_ppo_hl.py
@@ -114,7 +114,7 @@ def main(
                 forward_loss_weight=icm_forward_loss_weight,
             ),
         )
-    experiment = builder.build()
+    experiment = builder.build()[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/atari/atari_sac_hl.py
+++ b/examples/atari/atari_sac_hl.py
@@ -102,7 +102,7 @@ def main(
                 forward_loss_weight=icm_forward_loss_weight,
             ),
         )
-    experiment = builder.build()
+    experiment = builder.build()[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/discrete/discrete_dqn_hl.py
+++ b/examples/discrete/discrete_dqn_hl.py
@@ -53,7 +53,7 @@ def main() -> None:
         .with_epoch_test_callback(EpochTestCallbackDQNSetEps(0.0))
         .with_epoch_stop_callback(EpochStopCallbackRewardThreshold(195))
         .build()
-    )
+    )[0]
     experiment.run()
 
 

--- a/examples/mujoco/mujoco_a2c_hl.py
+++ b/examples/mujoco/mujoco_a2c_hl.py
@@ -82,7 +82,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, nn.Tanh, continuous_unbounded=True)
         .with_critic_factory_default(hidden_sizes, nn.Tanh)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_ddpg_hl.py
+++ b/examples/mujoco/mujoco_ddpg_hl.py
@@ -73,7 +73,7 @@ def main(
         .with_actor_factory_default(hidden_sizes)
         .with_critic_factory_default(hidden_sizes)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_npg_hl.py
+++ b/examples/mujoco/mujoco_npg_hl.py
@@ -84,7 +84,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh, continuous_unbounded=True)
         .with_critic_factory_default(hidden_sizes, torch.nn.Tanh)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_ppo_hl.py
+++ b/examples/mujoco/mujoco_ppo_hl.py
@@ -94,7 +94,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh, continuous_unbounded=True)
         .with_critic_factory_default(hidden_sizes, torch.nn.Tanh)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_ppo_hl_multi.py
+++ b/examples/mujoco/mujoco_ppo_hl_multi.py
@@ -13,7 +13,6 @@ These plots are saved in the log directory and displayed in the console.
 """
 
 import os
-import sys
 from collections.abc import Sequence
 from typing import Literal
 
@@ -48,7 +47,7 @@ def main(
     hidden_sizes: Sequence[int] = (64, 64),
     lr: float = 3e-4,
     gamma: float = 0.99,
-    epoch: int = 3,
+    epoch: int = 100,
     step_per_epoch: int = 30000,
     step_per_collect: int = 2048,
     repeat_per_collect: int = 10,
@@ -67,7 +66,7 @@ def main(
     value_clip: bool = False,
     norm_adv: bool = False,
     recompute_adv: bool = True,
-    run_experiments_sequentially: bool = True,
+    run_experiments_sequentially: bool = False,
 ) -> str:
     """Use the high-level API of TianShou to evaluate the PPO algorithm on a MuJoCo environment with multiple seeds for
     a given configuration. The results for each run are stored in separate sub-folders. After the agents are trained,
@@ -128,9 +127,7 @@ def main(
         train_seed=sampling_config.train_seed,
         test_seed=sampling_config.test_seed,
         obs_norm=True,
-        venv_type=VectorEnvType.SUBPROC_SHARED_MEM_FORK_CONTEXT
-        if sys.platform == "darwin"
-        else VectorEnvType.SUBPROC_SHARED_MEM,
+        venv_type=VectorEnvType.SUBPROC_SHARED_MEM_FORK_CONTEXT,
     )
 
     experiments = (
@@ -159,7 +156,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh, continuous_unbounded=True)
         .with_critic_factory_default(hidden_sizes, torch.nn.Tanh)
         .with_logger_factory(LoggerFactoryDefault("tensorboard"))
-        .build_default_seeded_experiments(num_experiments)
+        .build(num_experiments=num_experiments)
     )
 
     if run_experiments_sequentially:

--- a/examples/mujoco/mujoco_redq_hl.py
+++ b/examples/mujoco/mujoco_redq_hl.py
@@ -82,7 +82,7 @@ def main(
         .with_actor_factory_default(hidden_sizes)
         .with_critic_ensemble_factory_default(hidden_sizes)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_reinforce_hl.py
+++ b/examples/mujoco/mujoco_reinforce_hl.py
@@ -71,7 +71,7 @@ def main(
         )
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh, continuous_unbounded=True)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_sac_hl.py
+++ b/examples/mujoco/mujoco_sac_hl.py
@@ -79,7 +79,7 @@ def main(
         )
         .with_common_critic_factory_default(hidden_sizes)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_td3_hl.py
+++ b/examples/mujoco/mujoco_td3_hl.py
@@ -84,7 +84,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh)
         .with_common_critic_factory_default(hidden_sizes, torch.nn.Tanh)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/examples/mujoco/mujoco_trpo_hl.py
+++ b/examples/mujoco/mujoco_trpo_hl.py
@@ -88,7 +88,7 @@ def main(
         .with_actor_factory_default(hidden_sizes, torch.nn.Tanh, continuous_unbounded=True)
         .with_critic_factory_default(hidden_sizes, torch.nn.Tanh)
         .build()
-    )
+    )[0]
     experiment.run(override_experiment_name=log_name)
 
 

--- a/test/highlevel/test_experiment_builder.py
+++ b/test/highlevel/test_experiment_builder.py
@@ -48,7 +48,7 @@ def test_experiment_builder_continuous_default_params(builder_cls: type[Experime
         env_factory=env_factory,
         sampling_config=sampling_config,
     )
-    experiment = builder.build()
+    experiment = builder.build()[0]
     experiment.run(override_experiment_name="test")
     print(experiment)
 
@@ -76,7 +76,7 @@ def test_experiment_builder_discrete_default_params(builder_cls: type[Experiment
         env_factory=env_factory,
         sampling_config=sampling_config,
     )
-    experiment = builder.build()
+    experiment = builder.build()[0]
     experiment.run(override_experiment_name="test")
     print(experiment)
 
@@ -100,7 +100,7 @@ def test_temp_builder_modification() -> None:
     with builder.temp_config_mutation():
         builder.experiment_config.seed += 12345
         builder.sampling_config.train_seed += 456
-        exp = builder.build()
+        exp = builder.build()[0]
 
     assert builder.experiment_config.seed == original_seed
     assert builder.sampling_config.train_seed == original_train_seed


### PR DESCRIPTION
This is a suggestion for a single public build method that takes `num_experiments` as an argument and returns a  list of `num_experiments` experiments.