### PR TITLE
Added support for minibatch in PPO process_fn

### DIFF
--- a/tianshou/policy/modelfree/ppo.py
+++ b/tianshou/policy/modelfree/ppo.py
@@ -139,7 +139,7 @@ class PPOPolicy(A2CPolicy[TPPOTrainingStats], Generic[TPPOTrainingStats]):  # ty
         batch.act = to_torch_as(batch.act, batch.v_s)
         logp_old = []
         with torch.no_grad():
-            for minibatch in batch.split(self._batch, shuffle=False, merge_last=True):
+            for minibatch in batch.split(self.max_batchsize, shuffle=False, merge_last=True):
                 logp_old.append(self(minibatch).dist.log_prob(minibatch.act))
             batch.logp_old = torch.cat(logp_old, dim=0).flatten()
         batch: LogpOldProtocol

--- a/tianshou/policy/modelfree/ppo.py
+++ b/tianshou/policy/modelfree/ppo.py
@@ -137,8 +137,11 @@ class PPOPolicy(A2CPolicy[TPPOTrainingStats], Generic[TPPOTrainingStats]):  # ty
             self._buffer, self._indices = buffer, indices
         batch = self._compute_returns(batch, buffer, indices)
         batch.act = to_torch_as(batch.act, batch.v_s)
+        logp_old = []
         with torch.no_grad():
-            batch.logp_old = self(batch).dist.log_prob(batch.act)
+            for minibatch in batch.split(self._batch, shuffle=False, merge_last=True):
+                logp_old.append(self(minibatch).dist.log_prob(minibatch.act))
+            batch.logp_old = torch.cat(logp_old, dim=0).flatten()
         batch: LogpOldProtocol
         return batch
 


### PR DESCRIPTION
Closes #1164

In PPOPolicy, the method `process_fn()` now computes `logp_old` in minibatch instead of all at once.