### PR TITLE
Feature/improvements batch

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -270,4 +270,4 @@ v_s
 v_s_
 obs
 obs_next
-
+dtype

--- a/examples/inverse/irl_gail.py
+++ b/examples/inverse/irl_gail.py
@@ -4,7 +4,7 @@ import argparse
 import datetime
 import os
 import pprint
-from typing import SupportsFloat
+from typing import SupportsFloat, cast
 
 import d4rl
 import gymnasium as gym
@@ -16,6 +16,7 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.tensorboard import SummaryWriter
 
 from tianshou.data import Batch, Collector, ReplayBuffer, VectorReplayBuffer
+from tianshou.data.types import RolloutBatchProtocol
 from tianshou.env import SubprocVectorEnv, VectorEnvNormObs
 from tianshou.policy import GAILPolicy
 from tianshou.policy.base import BasePolicy
@@ -185,12 +186,15 @@ def test_gail(args: argparse.Namespace = get_args()) -> None:
 
     for i in range(dataset_size):
         expert_buffer.add(
-            Batch(
-                obs=dataset["observations"][i],
-                act=dataset["actions"][i],
-                rew=dataset["rewards"][i],
-                done=dataset["terminals"][i],
-                obs_next=dataset["next_observations"][i],
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=dataset["observations"][i],
+                    act=dataset["actions"][i],
+                    rew=dataset["rewards"][i],
+                    done=dataset["terminals"][i],
+                    obs_next=dataset["next_observations"][i],
+                ),
             ),
         )
     print("dataset loaded")

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -148,7 +148,7 @@ class MoveToRightEnv(gym.Env):
             self.terminated = True
             return self._get_state(), self._get_reward(), self.terminated, False, {}
 
-        info_dict = {"key": 1, "env": self} if self.dict_state else {}
+        info_dict = {"key": 1, "env": self}
         if action == 0:
             self.index = max(self.index - 1, 0)
             return (

--- a/test/base/env.py
+++ b/test/base/env.py
@@ -147,6 +147,8 @@ class MoveToRightEnv(gym.Env):
         if self.index == self.size:
             self.terminated = True
             return self._get_state(), self._get_reward(), self.terminated, False, {}
+
+        info_dict = {"key": 1, "env": self} if self.dict_state else {}
         if action == 0:
             self.index = max(self.index - 1, 0)
             return (
@@ -154,7 +156,7 @@ class MoveToRightEnv(gym.Env):
                 self._get_reward(),
                 self.terminated,
                 False,
-                {"key": 1, "env": self} if self.dict_state else {},
+                info_dict,
             )
         if action == 1:
             self.index += 1
@@ -164,7 +166,7 @@ class MoveToRightEnv(gym.Env):
                 self._get_reward(),
                 self.terminated,
                 False,
-                {"key": 1, "env": self},
+                info_dict,
             )
         return None
 

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -378,7 +378,7 @@ def test_batch_over_batch_to_torch() -> None:
         a=np.float64(1.0),
         b=Batch(c=np.ones((1,), dtype=np.float32), d=torch.ones((1,), dtype=torch.float64)),
     )
-    batch.b.__dict__["e"] = 1  # bypass the check
+    batch.b.set_array_at_key(np.array([1]), "e")
     batch.to_torch_()
     assert isinstance(batch.a, torch.Tensor)
     assert isinstance(batch.b.c, torch.Tensor)

--- a/test/base/test_batch.py
+++ b/test/base/test_batch.py
@@ -824,7 +824,7 @@ class TestAssignment:
         assert batch.hasnull()
 
     @staticmethod
-    def test_dropnull():
+    def test_dropnull() -> None:
         batch = Batch(a=[4, 5, 6], b=[7, 8, None], c={"d": np.array([None, 2.1, 3.0])})
         assert batch.dropnull() == Batch(a=[5], b=[8], c={"d": np.array([2.1])}).apply_array_func(
             np.atleast_1d,

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -21,6 +21,7 @@ from tianshou.data import (
     SegmentTree,
     VectorReplayBuffer,
 )
+from tianshou.data.types import RolloutBatchProtocol
 from tianshou.data.utils.converter import to_hdf5
 
 
@@ -34,14 +35,17 @@ def test_replaybuffer(size: int = 10, bufsize: int = 20) -> None:
     for i, act in enumerate(action_list):
         obs_next, rew, terminated, truncated, info = env.step(act)
         buf.add(
-            Batch(
-                obs=obs,
-                act=[act],
-                rew=rew,
-                terminated=terminated,
-                truncated=truncated,
-                obs_next=obs_next,
-                info=info,
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=obs,
+                    act=[act],
+                    rew=rew,
+                    terminated=terminated,
+                    truncated=truncated,
+                    obs_next=obs_next,
+                    info=info,
+                ),
             ),
         )
         obs = obs_next
@@ -58,33 +62,36 @@ def test_replaybuffer(size: int = 10, bufsize: int = 20) -> None:
     assert (data.terminated <= 1).all()
     assert (data.truncated >= 0).all()
     assert (data.truncated <= 1).all()
-    b = ReplayBuffer(size=10)
+    replay_buffer = ReplayBuffer(size=10)
     # neg bsz should return empty index
-    assert b.sample_indices(-1).tolist() == []
-    ptr, ep_rew, ep_len, ep_idx = b.add(
-        Batch(
-            obs=1,
-            act=1,
-            rew=1,
-            terminated=1,
-            truncated=0,
-            obs_next="str",
-            info={"a": 3, "b": {"c": 5.0}},
+    assert replay_buffer.sample_indices(-1).tolist() == []
+    ptr, ep_rew, ep_len, ep_idx = replay_buffer.add(
+        cast(
+            RolloutBatchProtocol,
+            Batch(
+                obs=1,
+                act=1,
+                rew=1,
+                terminated=1,
+                truncated=0,
+                obs_next="str",
+                info={"a": 3, "b": {"c": 5.0}},
+            ),
         ),
     )
-    assert b.obs[0] == 1
-    assert b.done[0]
-    assert b.terminated[0]
-    assert not b.truncated[0]
-    assert b.obs_next[0] == "str"
-    assert np.all(b.obs[1:] == 0)
-    assert np.all(b.obs_next[1:] == np.array(None))
-    assert b.info.a[0] == 3
-    assert b.info.a.dtype == int
-    assert np.all(b.info.a[1:] == 0)
-    assert b.info.b.c[0] == 5.0
-    assert b.info.b.c.dtype == float
-    assert np.all(b.info.b.c[1:] == 0.0)
+    assert replay_buffer.obs[0] == 1
+    assert replay_buffer.done[0]
+    assert replay_buffer.terminated[0]
+    assert not replay_buffer.truncated[0]
+    assert replay_buffer.obs_next[0] == "str"
+    assert np.all(replay_buffer.obs[1:] == 0)
+    assert np.all(replay_buffer.obs_next[1:] == np.array(None))
+    assert replay_buffer.info.a[0] == 3
+    assert replay_buffer.info.a.dtype == int
+    assert np.all(replay_buffer.info.a[1:] == 0)
+    assert replay_buffer.info.b.c[0] == 5.0
+    assert replay_buffer.info.b.c.dtype == float
+    assert np.all(replay_buffer.info.b.c[1:] == 0.0)
     assert ptr.shape == (1,)
     assert ptr[0] == 0
     assert ep_rew.shape == (1,)
@@ -94,28 +101,32 @@ def test_replaybuffer(size: int = 10, bufsize: int = 20) -> None:
     assert ep_idx.shape == (1,)
     assert ep_idx[0] == 0
     # test extra keys pop up, the buffer should handle it dynamically
-    batch = Batch(
-        obs=2,
-        act=2,
-        rew=2,
-        terminated=0,
-        truncated=0,
-        obs_next="str2",
-        info={"a": 4, "d": {"e": -np.inf}},
+    batch = cast(
+        RolloutBatchProtocol,
+        Batch(
+            obs=2,
+            act=2,
+            rew=2,
+            terminated=0,
+            truncated=0,
+            obs_next="str2",
+            info={"a": 4, "d": {"e": -np.inf}},
+        ),
     )
-    b.add(batch)
+    replay_buffer.add(batch)
     info_keys = ["a", "b", "d"]
-    assert set(b.info.keys()) == set(info_keys)
-    assert b.info.a[1] == 4
-    assert b.info.b.c[1] == 0
-    assert b.info.d.e[1] == -np.inf
+    assert set(replay_buffer.info.keys()) == set(info_keys)
+    assert replay_buffer.info.a[1] == 4
+    assert replay_buffer.info.b.c[1] == 0
+    assert replay_buffer.info.d.e[1] == -np.inf
     # test batch-style adding method, where len(batch) == 1
     batch.done = [1]
-    batch.terminated = [0]
-    batch.truncated = [1]
+    batch.terminated = [0]  # type: ignore[assignment]
+    batch.truncated = [1]  # type: ignore[assignment]
+    assert isinstance(batch.info, Batch)
     batch.info.e = np.zeros([1, 4])
     batch = Batch.stack([batch])
-    ptr, ep_rew, ep_len, ep_idx = b.add(batch, buffer_ids=[0])
+    ptr, ep_rew, ep_len, ep_idx = replay_buffer.add(batch, buffer_ids=[0])
     assert ptr.shape == (1,)
     assert ptr[0] == 2
     assert ep_rew.shape == (1,)
@@ -124,17 +135,17 @@ def test_replaybuffer(size: int = 10, bufsize: int = 20) -> None:
     assert ep_len[0] == 2
     assert ep_idx.shape == (1,)
     assert ep_idx[0] == 1
-    assert set(b.info.keys()) == {*info_keys, "e"}
-    assert b.info.e.shape == (b.maxsize, 1, 4)
+    assert set(replay_buffer.info.keys()) == {*info_keys, "e"}
+    assert replay_buffer.info.e.shape == (replay_buffer.maxsize, 1, 4)
     with pytest.raises(IndexError):
-        b[22]
+        replay_buffer[22]
     # test prev / next
-    assert np.all(b.prev(np.array([0, 1, 2])) == [0, 1, 1])
-    assert np.all(b.next(np.array([0, 1, 2])) == [0, 2, 2])
+    assert np.all(replay_buffer.prev(np.array([0, 1, 2])) == [0, 1, 1])
+    assert np.all(replay_buffer.next(np.array([0, 1, 2])) == [0, 2, 2])
     batch.done = [0]
-    b.add(batch, buffer_ids=[0])
-    assert np.all(b.prev(np.array([0, 1, 2, 3])) == [0, 1, 1, 3])
-    assert np.all(b.next(np.array([0, 1, 2, 3])) == [0, 2, 2, 3])
+    replay_buffer.add(batch, buffer_ids=[0])
+    assert np.all(replay_buffer.prev(np.array([0, 1, 2, 3])) == [0, 1, 1, 3])
+    assert np.all(replay_buffer.next(np.array([0, 1, 2, 3])) == [0, 2, 2, 3])
 
 
 def test_ignore_obs_next(size: int = 10) -> None:
@@ -142,17 +153,20 @@ def test_ignore_obs_next(size: int = 10) -> None:
     buf = ReplayBuffer(size, ignore_obs_next=True)
     for i in range(size):
         buf.add(
-            Batch(
-                obs={
-                    "mask1": np.array([i, 1, 1, 0, 0]),
-                    "mask2": np.array([i + 4, 0, 1, 0, 0]),
-                    "mask": i,
-                },
-                act={"act_id": i, "position_id": i + 3},
-                rew=i,
-                terminated=i % 3 == 0,
-                truncated=False,
-                info={"if": i},
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs={
+                        "mask1": np.array([i, 1, 1, 0, 0]),
+                        "mask2": np.array([i + 4, 0, 1, 0, 0]),
+                        "mask": i,
+                    },
+                    act={"act_id": i, "position_id": i + 3},
+                    rew=i,
+                    terminated=i % 3 == 0,
+                    truncated=False,
+                    info={"if": i},
+                ),
             ),
         )
     indices = np.arange(len(buf))
@@ -224,34 +238,43 @@ def test_stack(size: int = 5, bufsize: int = 9, stack_num: int = 4, cached_num: 
         obs_next, rew, terminated, truncated, info = env.step(1)
         done = terminated or truncated
         buf.add(
-            Batch(
-                obs=obs,
-                act=1,
-                rew=rew,
-                terminated=terminated,
-                truncated=truncated,
-                info=info,
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=obs,
+                    act=1,
+                    rew=rew,
+                    terminated=terminated,
+                    truncated=truncated,
+                    info=info,
+                ),
             ),
         )
         buf2.add(
-            Batch(
-                obs=obs,
-                act=1,
-                rew=rew,
-                terminated=terminated,
-                truncated=truncated,
-                info=info,
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=obs,
+                    act=1,
+                    rew=rew,
+                    terminated=terminated,
+                    truncated=truncated,
+                    info=info,
+                ),
             ),
         )
         buf3.add(
-            Batch(
-                obs=[obs, obs, obs],
-                act=1,
-                rew=rew,
-                terminated=terminated,
-                truncated=truncated,
-                obs_next=[obs, obs],
-                info=info,
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=[obs, obs, obs],
+                    act=1,
+                    rew=rew,
+                    terminated=terminated,
+                    truncated=truncated,
+                    obs_next=[obs, obs],
+                    info=info,
+                ),
             ),
         )
         obs = obs_next
@@ -293,15 +316,18 @@ def test_priortized_replaybuffer(size: int = 32, bufsize: int = 15) -> None:
     action_list = [1] * 5 + [0] * 10 + [1] * 10
     for i, act in enumerate(action_list):
         obs_next, rew, terminated, truncated, info = env.step(act)
-        batch = Batch(
-            obs=obs,
-            act=act,
-            rew=rew,
-            terminated=terminated,
-            truncated=truncated,
-            obs_next=obs_next,
-            info=info,
-            policy=np.random.randn() - 0.5,
+        batch = cast(
+            RolloutBatchProtocol,
+            Batch(
+                obs=obs,
+                act=act,
+                rew=rew,
+                terminated=terminated,
+                truncated=truncated,
+                obs_next=obs_next,
+                info=info,
+                policy=np.random.randn() - 0.5,
+            ),
         )
         batch_stack = Batch.stack([batch, batch, batch])
         buf.add(Batch.stack([batch]), buffer_ids=[0])
@@ -362,14 +388,17 @@ def test_herreplaybuffer(size: int = 10, bufsize: int = 100, sample_sz: int = 4)
     action_list = [1] * 5 + [0] * 10 + [1] * 10
     for i, act in enumerate(action_list):
         obs_next, rew, terminated, truncated, info = env.step(act)
-        batch = Batch(
-            obs=obs,
-            act=[act],
-            rew=rew,
-            terminated=terminated,
-            truncated=truncated,
-            obs_next=obs_next,
-            info=info,
+        batch = cast(
+            RolloutBatchProtocol,
+            Batch(
+                obs=obs,
+                act=[act],
+                rew=rew,
+                terminated=terminated,
+                truncated=truncated,
+                obs_next=obs_next,
+                info=info,
+            ),
         )
         buf.add(batch)
         buf2.add(Batch.stack([batch, batch, batch]), buffer_ids=[0, 1, 2])
@@ -448,14 +477,17 @@ def test_herreplaybuffer(size: int = 10, bufsize: int = 100, sample_sz: int = 4)
         for i in range(ep_len):
             act = 1
             obs_next, rew, terminated, truncated, info = env.step(act)
-            batch = Batch(
-                obs=obs,
-                act=[act],
-                rew=rew,
-                terminated=(i == ep_len - 1),
-                truncated=(i == ep_len - 1),
-                obs_next=obs_next,
-                info=info,
+            batch = cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=obs,
+                    act=[act],
+                    rew=rew,
+                    terminated=(i == ep_len - 1),
+                    truncated=(i == ep_len - 1),
+                    obs_next=obs_next,
+                    info=info,
+                ),
             )
             buf.add(batch)
             obs = obs_next
@@ -476,14 +508,17 @@ def test_herreplaybuffer(size: int = 10, bufsize: int = 100, sample_sz: int = 4)
         for i in range(ep_len):
             act = 1
             obs_next, rew, terminated, truncated, info = env.step(act)
-            batch = Batch(
-                obs=obs,
-                act=[act],
-                rew=rew,
-                terminated=(i == ep_len - 1),
-                truncated=(i == ep_len - 1),
-                obs_next=obs_next,
-                info=info,
+            batch = cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=obs,
+                    act=[act],
+                    rew=rew,
+                    terminated=(i == ep_len - 1),
+                    truncated=(i == ep_len - 1),
+                    obs_next=obs_next,
+                    info=info,
+                ),
             )
             if x == 1 and obs["observation"] < 10:
                 obs = obs_next
@@ -501,13 +536,16 @@ def test_update() -> None:
     buf2 = ReplayBuffer(4, stack_num=2)
     for i in range(5):
         buf1.add(
-            Batch(
-                obs=np.array([i]),
-                act=float(i),
-                rew=i * i,
-                terminated=i % 2 == 0,
-                truncated=False,
-                info={"incident": "found"},
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=np.array([i]),
+                    act=float(i),
+                    rew=i * i,
+                    terminated=i % 2 == 0,
+                    truncated=False,
+                    info={"incident": "found"},
+                ),
             ),
         )
     assert len(buf1) > len(buf2)
@@ -610,23 +648,29 @@ def test_pickle() -> None:
     rew = np.array([1, 1])
     for i in range(4):
         vbuf.add(
-            Batch(
-                obs=Batch(index=np.array([i])),
-                act=0,
-                rew=rew,
-                terminated=0,
-                truncated=0,
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=Batch(index=np.array([i])),
+                    act=0,
+                    rew=rew,
+                    terminated=0,
+                    truncated=0,
+                ),
             ),
         )
     for i in range(5):
         pbuf.add(
-            Batch(
-                obs=Batch(index=np.array([i])),
-                act=2,
-                rew=rew,
-                terminated=0,
-                truncated=0,
-                info=np.random.rand(),
+            cast(
+                RolloutBatchProtocol,
+                Batch(
+                    obs=Batch(index=np.array([i])),
+                    act=2,
+                    rew=rew,
+                    terminated=0,
+                    truncated=0,
+                    info=np.random.rand(),
+                ),
             ),
         )
     # save & load
@@ -660,8 +704,8 @@ def test_hdf5() -> None:
             "done": i % 3 == 2,
             "info": {"number": {"n": i, "t": info_t}, "extra": None},
         }
-        buffers["array"].add(Batch(kwargs))
-        buffers["prioritized"].add(Batch(kwargs))
+        buffers["array"].add(cast(RolloutBatchProtocol, Batch(kwargs)))
+        buffers["prioritized"].add(cast(RolloutBatchProtocol, Batch(kwargs)))
 
     # save
     paths = {}
@@ -703,12 +747,15 @@ def test_hdf5() -> None:
 
 def test_replaybuffermanager() -> None:
     buf = VectorReplayBuffer(20, 4)
-    batch = Batch(
-        obs=[1, 2, 3],
-        act=[1, 2, 3],
-        rew=[1, 2, 3],
-        terminated=[0, 0, 1],
-        truncated=[0, 0, 0],
+    batch = cast(
+        RolloutBatchProtocol,
+        Batch(
+            obs=[1, 2, 3],
+            act=[1, 2, 3],
+            rew=[1, 2, 3],
+            terminated=[0, 0, 1],
+            truncated=[0, 0, 0],
+        ),
     )
     ptr, ep_rew, ep_len, ep_idx = buf.add(batch, buffer_ids=[0, 1, 2])
     assert np.all(ep_len == [0, 0, 1])
@@ -728,7 +775,10 @@ def test_replaybuffermanager() -> None:
     indices_next = buf.next(indices)
     assert np.allclose(indices_next, indices), indices_next
     assert np.allclose(buf.unfinished_index(), [0, 5])
-    buf.add(Batch(obs=[4], act=[4], rew=[4], terminated=[1], truncated=[0]), buffer_ids=[3])
+    buf.add(
+        cast(RolloutBatchProtocol, Batch(obs=[4], act=[4], rew=[4], terminated=[1], truncated=[0])),
+        buffer_ids=[3],
+    )
     assert np.allclose(buf.unfinished_index(), [0, 5])
     batch, indices = buf.sample(10)
     batch, indices = buf.sample(0)
@@ -739,20 +789,32 @@ def test_replaybuffermanager() -> None:
     assert np.allclose(indices_next, indices), indices_next
     data = np.array([0, 0, 0, 0])
     buf.add(
-        Batch(obs=data, act=data, rew=data, terminated=data, truncated=data),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=data, terminated=data, truncated=data),
+        ),
         buffer_ids=[0, 1, 2, 3],
     )
     buf.add(
-        Batch(obs=data, act=data, rew=data, terminated=1 - data, truncated=data),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=data, terminated=1 - data, truncated=data),
+        ),
         buffer_ids=[0, 1, 2, 3],
     )
     assert len(buf) == 12
     buf.add(
-        Batch(obs=data, act=data, rew=data, terminated=data, truncated=data),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=data, terminated=data, truncated=data),
+        ),
         buffer_ids=[0, 1, 2, 3],
     )
     buf.add(
-        Batch(obs=data, act=data, rew=data, terminated=[0, 1, 0, 1], truncated=data),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=data, terminated=[0, 1, 0, 1], truncated=data),
+        ),
         buffer_ids=[0, 1, 2, 3],
     )
     assert len(buf) == 20
@@ -839,7 +901,7 @@ def test_replaybuffermanager() -> None:
     )
     assert np.allclose(buf.unfinished_index(), [4, 14])
     ptr, ep_rew, ep_len, ep_idx = buf.add(
-        Batch(obs=[1], act=[1], rew=[1], terminated=[1], truncated=[0]),
+        cast(RolloutBatchProtocol, Batch(obs=[1], act=[1], rew=[1], terminated=[1], truncated=[0])),
         buffer_ids=[2],
     )
     assert np.all(ep_len == [3])
@@ -915,7 +977,7 @@ def test_cachedbuffer() -> None:
     assert buf.sample_indices(0).tolist() == []
     # check the normal function/usage/storage in CachedReplayBuffer
     ptr, ep_rew, ep_len, ep_idx = buf.add(
-        Batch(obs=[1], act=[1], rew=[1], terminated=[0], truncated=[0]),
+        cast(RolloutBatchProtocol, Batch(obs=[1], act=[1], rew=[1], terminated=[0], truncated=[0])),
         buffer_ids=[1],
     )
     obs = np.zeros(buf.maxsize)
@@ -930,7 +992,7 @@ def test_cachedbuffer() -> None:
     assert np.all(ptr == [15])
     assert np.all(ep_idx == [15])
     ptr, ep_rew, ep_len, ep_idx = buf.add(
-        Batch(obs=[2], act=[2], rew=[2], terminated=[1], truncated=[0]),
+        cast(RolloutBatchProtocol, Batch(obs=[2], act=[2], rew=[2], terminated=[1], truncated=[0])),
         buffer_ids=[3],
     )
     obs[[0, 25]] = 2
@@ -946,7 +1008,10 @@ def test_cachedbuffer() -> None:
     assert np.allclose(buf.unfinished_index(), [15])
     assert np.allclose(buf.sample_indices(0), [0, 15])
     ptr, ep_rew, ep_len, ep_idx = buf.add(
-        Batch(obs=[3, 4], act=[3, 4], rew=[3, 4], terminated=[0, 1], truncated=[0, 0]),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=[3, 4], act=[3, 4], rew=[3, 4], terminated=[0, 1], truncated=[0, 0]),
+        ),
         buffer_ids=[3, 1],  # TODO
     )
     assert np.all(ep_len == [0, 2])
@@ -968,12 +1033,35 @@ def test_cachedbuffer() -> None:
     buf = CachedReplayBuffer(ReplayBuffer(0, sample_avail=True), 4, 5)
     data = np.zeros(4)
     rew = np.ones([4, 4])
-    buf.add(Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 1, 1], truncated=[0, 0, 0, 0]))
-    buf.add(Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 0, 0], truncated=[0, 0, 0, 0]))
-    buf.add(Batch(obs=data, act=data, rew=rew, terminated=[1, 1, 1, 1], truncated=[0, 0, 0, 0]))
-    buf.add(Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 0, 0], truncated=[0, 0, 0, 0]))
+    buf.add(
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 1, 1], truncated=[0, 0, 0, 0]),
+        ),
+    )
+    buf.add(
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 0, 0], truncated=[0, 0, 0, 0]),
+        ),
+    )
+    buf.add(
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=rew, terminated=[1, 1, 1, 1], truncated=[0, 0, 0, 0]),
+        ),
+    )
+    buf.add(
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=rew, terminated=[0, 0, 0, 0], truncated=[0, 0, 0, 0]),
+        ),
+    )
     ptr, ep_rew, ep_len, ep_idx = buf.add(
-        Batch(obs=data, act=data, rew=rew, terminated=[0, 1, 0, 1], truncated=[0, 0, 0, 0]),
+        cast(
+            RolloutBatchProtocol,
+            Batch(obs=data, act=data, rew=rew, terminated=[0, 1, 0, 1], truncated=[0, 0, 0, 0]),
+        ),
     )
     assert np.all(ptr == [1, -1, 11, -1])
     assert np.all(ep_idx == [0, -1, 10, -1])
@@ -1041,14 +1129,17 @@ def test_multibuf_stack() -> None:
         truncated_list = [truncated] * cached_num
         obs_next_list = -obs_list
         info_list = [info] * cached_num
-        batch = Batch(
-            obs=obs_list,
-            act=act_list,
-            rew=rew_list,
-            terminated=terminated_list,
-            truncated=truncated_list,
-            obs_next=obs_next_list,
-            info=info_list,
+        batch = cast(
+            RolloutBatchProtocol,
+            Batch(
+                obs=obs_list,
+                act=act_list,
+                rew=rew_list,
+                terminated=terminated_list,
+                truncated=truncated_list,
+                obs_next=obs_next_list,
+                info=info_list,
+            ),
         )
         buf5.add(batch)
         buf4.add(batch)
@@ -1184,13 +1275,16 @@ def test_multibuf_stack() -> None:
     )
     obs = np.random.rand(size, 4, 84, 84)
     buf6.add(
-        Batch(
-            obs=[obs[2], obs[0]],
-            act=[1, 1],
-            rew=[0, 0],
-            terminated=[0, 1],
-            truncated=[0, 0],
-            obs_next=[obs[3], obs[1]],
+        cast(
+            RolloutBatchProtocol,
+            Batch(
+                obs=[obs[2], obs[0]],
+                act=[1, 1],
+                rew=[0, 0],
+                terminated=[0, 1],
+                truncated=[0, 0],
+                obs_next=[obs[3], obs[1]],
+            ),
         ),
         buffer_ids=[1, 2],
     )
@@ -1309,49 +1403,52 @@ def test_from_data() -> None:
 
 
 def test_custom_key() -> None:
-    batch = Batch(
-        obs_next=np.array(
-            [
+    batch = cast(
+        RolloutBatchProtocol,
+        Batch(
+            obs_next=np.array(
                 [
-                    1.174,
-                    -0.1151,
-                    -0.609,
-                    -0.5205,
-                    -0.9316,
-                    3.236,
-                    -2.418,
-                    0.386,
-                    0.2227,
-                    -0.5117,
-                    2.293,
+                    [
+                        1.174,
+                        -0.1151,
+                        -0.609,
+                        -0.5205,
+                        -0.9316,
+                        3.236,
+                        -2.418,
+                        0.386,
+                        0.2227,
+                        -0.5117,
+                        2.293,
+                    ],
                 ],
-            ],
-        ),
-        rew=np.array([4.28125]),
-        act=np.array([[-0.3088, -0.4636, 0.4956]]),
-        truncated=np.array([False]),
-        obs=np.array(
-            [
+            ),
+            rew=np.array([4.28125]),
+            act=np.array([[-0.3088, -0.4636, 0.4956]]),
+            truncated=np.array([False]),
+            obs=np.array(
                 [
-                    1.193,
-                    -0.1203,
-                    -0.6123,
-                    -0.519,
-                    -0.9434,
-                    3.32,
-                    -2.266,
-                    0.9116,
-                    0.623,
-                    0.1259,
-                    0.363,
+                    [
+                        1.193,
+                        -0.1203,
+                        -0.6123,
+                        -0.519,
+                        -0.9434,
+                        3.32,
+                        -2.266,
+                        0.9116,
+                        0.623,
+                        0.1259,
+                        0.363,
+                    ],
                 ],
-            ],
+            ),
+            terminated=np.array([False]),
+            done=np.array([False]),
+            returns=np.array([74.70343082]),
+            info=Batch(),
+            policy=Batch(),
         ),
-        terminated=np.array([False]),
-        done=np.array([False]),
-        returns=np.array([74.70343082]),
-        info=Batch(),
-        policy=Batch(),
     )
     buffer_size = len(batch.rew)
     buffer = ReplayBuffer(buffer_size)

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -312,7 +312,7 @@ def test_priortized_replaybuffer(size: int = 32, bufsize: int = 15) -> None:
     env = MoveToRightEnv(size)
     buf = PrioritizedReplayBuffer(bufsize, 0.5, 0.5)
     buf2 = PrioritizedVectorReplayBuffer(bufsize, buffer_num=3, alpha=0.5, beta=0.5)
-    obs, info = env.reset()
+    obs, _ = env.reset()
     action_list = [1] * 5 + [0] * 10 + [1] * 10
     for i, act in enumerate(action_list):
         obs_next, rew, terminated, truncated, info = env.step(act)

--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
 from test.base.env import MoveToRightEnv, NXEnv
-from typing import Any
+from typing import Any, cast
 
 import gymnasium as gym
 import numpy as np
@@ -17,7 +17,11 @@ from tianshou.data import (
     VectorReplayBuffer,
 )
 from tianshou.data.batch import BatchProtocol
-from tianshou.data.types import ObsBatchProtocol, RolloutBatchProtocol
+from tianshou.data.types import (
+    ActStateBatchProtocol,
+    ObsBatchProtocol,
+    RolloutBatchProtocol,
+)
 from tianshou.env import DummyVectorEnv, SubprocVectorEnv
 from tianshou.policy import BasePolicy, TrainingStats
 
@@ -54,7 +58,7 @@ class MaxActionPolicy(BasePolicy):
         batch: ObsBatchProtocol,
         state: dict | BatchProtocol | np.ndarray | None = None,
         **kwargs: Any,
-    ) -> Batch:
+    ) -> ActStateBatchProtocol:
         if self.need_state:
             if state is None:
                 state = np.zeros((len(batch.obs), 2))
@@ -69,9 +73,9 @@ class MaxActionPolicy(BasePolicy):
                 action_shape = len(batch.obs["index"])
             else:
                 action_shape = len(batch.obs)
-            return Batch(act=np.ones(action_shape), state=state)
+            return cast(ActStateBatchProtocol, Batch(act=np.ones(action_shape), state=state))
         action_shape = self.action_shape if self.action_shape else len(batch.obs)
-        return Batch(act=np.ones(action_shape), state=state)
+        return cast(ActStateBatchProtocol, Batch(act=np.ones(action_shape), state=state))
 
     def learn(self, batch: RolloutBatchProtocol, *args: Any, **kwargs: Any) -> TrainingStats:
         raise NotImplementedError

--- a/test/base/test_env_finite.py
+++ b/test/base/test_env_finite.py
@@ -12,7 +12,12 @@ from gymnasium.spaces import Box
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 
 from tianshou.data import Batch, Collector
-from tianshou.data.types import BatchProtocol, ObsBatchProtocol, RolloutBatchProtocol
+from tianshou.data.types import (
+    ActBatchProtocol,
+    BatchProtocol,
+    ObsBatchProtocol,
+    RolloutBatchProtocol,
+)
 from tianshou.env import BaseVectorEnv, DummyVectorEnv, SubprocVectorEnv
 from tianshou.env.utils import ENV_TYPE, gym_new_venv_step_type
 from tianshou.policy import BasePolicy
@@ -208,8 +213,8 @@ class AnyPolicy(BasePolicy):
         batch: ObsBatchProtocol,
         state: dict | BatchProtocol | np.ndarray | None = None,
         **kwargs: Any,
-    ) -> Batch:
-        return Batch(act=np.stack([1] * len(batch)))
+    ) -> ActBatchProtocol:
+        return cast(ActBatchProtocol, Batch(act=np.stack([1] * len(batch))))
 
     def learn(self, batch: RolloutBatchProtocol, *args: Any, **kwargs: Any) -> None:
         pass

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -1254,7 +1254,7 @@ class Batch(BatchProtocol):
 
         This is useful for extracting the structure of a batch without the actual data,
         especially in combination with `apply_values_transform` with a
-        transform function à la `lambda x: None`.
+        transform function a la `lambda x: None`.
         """
         empty_batch = Batch()
         for key, val in self.items():

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -1089,7 +1089,7 @@ class Batch(BatchProtocol):
                     # an unsized array with a boolean, e.g. np.array(False). behaves like the boolean itself
                     if val:
                         return True
-            return None
+            return False
 
         return is_any_true(is_any_null_batch)
 

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -211,7 +211,7 @@ class ProtocolCalledException(Exception):
     Currently, no static type checker actually verifies that a class that inherits
     from a Protocol does in fact provide the correct interface. Thus, it may happen
     that a method of the protocol is called accidentally (this is an
-    implementation error). The normal error for that is a somewhat cryptical
+    implementation error). The normal error for that is a somewhat cryptic
     AttributeError, wherefore we instead raise this custom exception in the
     BatchProtocol.
 
@@ -471,16 +471,17 @@ class BatchProtocol(Protocol):
     ) -> None:
         """Set a sequence of values at a given key.
 
-        If index is not passed, the sequence must have the same length as the batch.
+        If `index` is not passed, the sequence must have the same length as the batch.
+
         :param seq: the array of values to set.
         :param key: the key to set the sequence at.
         :param index: the indices to set the sequence at. If None, the sequence must have
             the same length as the batch and will be set at all indices.
-        :param default_value: this only applies if index is passed an the key does not exist yet
-            in the batch. In that case entries outside the passed index will be filled
+        :param default_value: this only applies if `index` is passed and the key does not exist yet
+            in the batch. In that case, entries outside the passed index will be filled
             with this default value.
             Note that the array at the key will be of the same dtype as the passed sequence,
-            so default value should be such that numpy can cast it to this dtype.
+            so `default_value` should be such that numpy can cast it to this dtype.
         """
         raise ProtocolCalledException
 

--- a/tianshou/data/buffer/base.py
+++ b/tianshou/data/buffer/base.py
@@ -355,7 +355,7 @@ class ReplayBuffer:
             set, return this default_value.
         :param stack_num: Default to self.stack_num.
         """
-        if key not in self._meta and default_value is not None:
+        if key not in self._meta.get_keys() and default_value is not None:
             return default_value
         val = self._meta[key]
         if stack_num is None:

--- a/tianshou/data/buffer/prio.py
+++ b/tianshou/data/buffer/prio.py
@@ -103,5 +103,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         batch.weight = weight / np.max(weight) if self._weight_norm else weight
         return cast(PrioBatchProtocol, batch)
 
+    def sample(self, batch_size: int | None) -> tuple[PrioBatchProtocol, np.ndarray]:
+        return cast(tuple[PrioBatchProtocol, np.ndarray], super().sample(batch_size=batch_size))
+
     def set_beta(self, beta: float) -> None:
         self._beta = beta

--- a/tianshou/data/types.py
+++ b/tianshou/data/types.py
@@ -20,7 +20,7 @@ class ObsBatchProtocol(BatchProtocol, Protocol):
     """
 
     obs: arr_type | BatchProtocol
-    info: arr_type
+    info: arr_type | BatchProtocol
 
 
 class RolloutBatchProtocol(ObsBatchProtocol, Protocol):

--- a/tianshou/data/types.py
+++ b/tianshou/data/types.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 
 from tianshou.data import Batch
-from tianshou.data.batch import BatchProtocol, arr_type
+from tianshou.data.batch import BatchProtocol, TArr
 
 TNestedDictValue = np.ndarray | dict[str, "TNestedDictValue"]
 
@@ -19,24 +19,24 @@ class ObsBatchProtocol(BatchProtocol, Protocol):
     Typically used inside a policy's forward
     """
 
-    obs: arr_type | BatchProtocol
-    info: arr_type | BatchProtocol
+    obs: TArr | BatchProtocol
+    info: TArr | BatchProtocol
 
 
 class RolloutBatchProtocol(ObsBatchProtocol, Protocol):
     """Typically, the outcome of sampling from a replay buffer."""
 
-    obs_next: arr_type | BatchProtocol
-    act: arr_type
+    obs_next: TArr | BatchProtocol
+    act: TArr
     rew: np.ndarray
-    terminated: arr_type
-    truncated: arr_type
+    terminated: TArr
+    truncated: TArr
 
 
 class BatchWithReturnsProtocol(RolloutBatchProtocol, Protocol):
     """With added returns, usually computed with GAE."""
 
-    returns: arr_type
+    returns: TArr
 
 
 class PrioBatchProtocol(RolloutBatchProtocol, Protocol):
@@ -55,7 +55,7 @@ class RecurrentStateBatch(BatchProtocol, Protocol):
 class ActBatchProtocol(BatchProtocol, Protocol):
     """Simplest batch, just containing the action. Useful e.g., for random policy."""
 
-    act: arr_type
+    act: TArr
 
 
 class ActStateBatchProtocol(ActBatchProtocol, Protocol):

--- a/tianshou/policy/base.py
+++ b/tianshou/policy/base.py
@@ -15,7 +15,7 @@ from overrides import override
 from torch import nn
 
 from tianshou.data import ReplayBuffer, SequenceSummaryStats, to_numpy, to_torch_as
-from tianshou.data.batch import Batch, BatchProtocol, arr_type
+from tianshou.data.batch import Batch, BatchProtocol, TArr
 from tianshou.data.buffer.base import TBuffer
 from tianshou.data.types import (
     ActBatchProtocol,
@@ -355,7 +355,7 @@ class BasePolicy(nn.Module, Generic[TTrainingStats], ABC):
         """
 
     @staticmethod
-    def _action_to_numpy(act: arr_type) -> np.ndarray:
+    def _action_to_numpy(act: TArr) -> np.ndarray:
         act = to_numpy(act)  # NOTE: to_numpy could confusingly also return a Batch
         if not isinstance(act, np.ndarray):
             raise ValueError(
@@ -365,7 +365,7 @@ class BasePolicy(nn.Module, Generic[TTrainingStats], ABC):
 
     def map_action(
         self,
-        act: arr_type,
+        act: TArr,
     ) -> np.ndarray:
         """Map raw network output to action range in gym's env.action_space.
 
@@ -400,7 +400,7 @@ class BasePolicy(nn.Module, Generic[TTrainingStats], ABC):
 
     def map_action_inverse(
         self,
-        act: arr_type,
+        act: TArr,
     ) -> np.ndarray:
         """Inverse operation to :meth:`~tianshou.policy.BasePolicy.map_action`.
 

--- a/tianshou/policy/imitation/bcq.py
+++ b/tianshou/policy/imitation/bcq.py
@@ -196,8 +196,10 @@ class BCQPolicy(BasePolicy[TBCQTrainingStats], Generic[TBCQTrainingStats]):
             # now target_Q: (batch_size, 1)
 
             target_Q = (
-                batch.rew.reshape(-1, 1) + (1 - batch.done).reshape(-1, 1) * self.gamma * target_Q
+                batch.rew.reshape(-1, 1)
+                + torch.logical_not(batch.done).reshape(-1, 1) * self.gamma * target_Q
             )
+            target_Q = target_Q.float()
 
         current_Q1 = self.critic(obs, act)
         current_Q2 = self.critic2(obs, act)

--- a/tianshou/policy/imitation/cql.py
+++ b/tianshou/policy/imitation/cql.py
@@ -280,7 +280,8 @@ class CQLPolicy(SACPolicy[TCQLTrainingStats]):
 
             target_Q = torch.min(target_Q1, target_Q2) - self.alpha * new_log_pi
 
-            target_Q = rew + self.gamma * (1 - batch.done) * target_Q.flatten()
+            target_Q = rew + torch.logical_not(batch.done) * self.gamma * target_Q.flatten()
+            target_Q = target_Q.float()
             # shape: (batch_size)
 
         # compute critic loss

--- a/tianshou/policy/multiagent/mapolicy.py
+++ b/tianshou/policy/multiagent/mapolicy.py
@@ -158,7 +158,7 @@ class MultiAgentPolicyManager(BasePolicy):
             results[agent] = policy.process_fn(tmp_batch, buffer, tmp_indice)
         if has_rew:  # restore from save_rew
             buffer._meta.rew = save_rew
-        return Batch(results)
+        return cast(MAPRolloutBatchProtocol, Batch(results))
 
     _TArrOrActBatch = TypeVar("_TArrOrActBatch", bound="np.ndarray | ActBatchProtocol")
 


### PR DESCRIPTION
This PR contains several important extensions and improvements of Batch.

1. A method for setting a new sequence. This is a first step towards using code that's less reliant on setting attributes directly. The method also permits setting a subsequence and filling up with default values. This will help ensuring that all entries in a batch are of the same length, something that we should start enforcing soon.
2. A new method for applying arbitrary transformations to "leaves" in a Batch. This simplifies already existing code and is generally very handy for users
3. The arbitrary transformations allowed implementing `isnull`, `hasnull` and `dropnull`, which helps finding errors early.
4. The arbitrary transformations now also allow extracting a `schema` from a batch. This was used in `Batch.cat_` to perform additional input validation (we now make sure there that the structures are the same when concatenating batches). This input validation is a **breaking change**! Some tests that concatenated incompatible batches were removed. Eventually, we can add a `get_schema` method to the batch that will retrieve metainfo like shapes and datatypes. For now, this is delegated to the user who can use the new `apply_values_transform`
5. New feature: slicing of torch distributions. Previously several batches contained instances of `Distribution` which were not properly sliced, inviting bugs and errors in user code. This is now fixed - albeit not in a pretty way (torch doesn't allow slicing the objects natively)
6. Stricter typing and some further minor extensions and simplifications

The new code was extensively tested and documented.