### PR TITLE
Lower level access to hl world

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -102,6 +102,10 @@ sphinx:
   recursive_update          : false # A boolean indicating whether to overwrite the Sphinx config (true) or recursively update (false)
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration
     autodoc_typehints_format: "short"
+    autodoc_member_order: "bysource"
+    autoclass_content: "both"
+    autodoc_default_options:
+      show-inheritance: True
     html_js_files:
 #     We have to list them explicitly because they need to be loaded in a specific order
       - js/vega@5.js

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -271,3 +271,8 @@ v_s_
 obs
 obs_next
 dtype
+entrypoint
+interquantile
+init
+kwarg
+kwargs

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -276,3 +276,7 @@ interquantile
 init
 kwarg
 kwargs
+autocompletion
+codebase
+indexable
+sliceable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ ignore = [
     "D212", # no blank line after """. This clashes with sphinx for multiline descriptions of :param: that start directly after """
     "PLW2901", # overwrite vars in loop
     "B027", # empty and non-abstract method in abstract class
+    "D404", # It's fine to start with "This" in docstrings
 ]
 unfixable = [
     "F841", # unused variable. ruff keeps the call, but mostly we want to get rid of it all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ ignore = [
     "D106", # undocumented public nested class
     "D205", # blank line after summary (prevents summary-only docstrings, which makes no sense)
     "PLW2901", # overwrite vars in loop
+    "B027", # empty and non-abstract method in abstract class
 ]
 unfixable = [
     "F841", # unused variable. ruff keeps the call, but mostly we want to get rid of it all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ ignore = [
     "RET505",
     "D106", # undocumented public nested class
     "D205", # blank line after summary (prevents summary-only docstrings, which makes no sense)
+    "D212", # no blank line after """. This clashes with sphinx for multiline descriptions of :param: that start directly after """
     "PLW2901", # overwrite vars in loop
     "B027", # empty and non-abstract method in abstract class
 ]

--- a/tianshou/data/batch.py
+++ b/tianshou/data/batch.py
@@ -607,10 +607,10 @@ class Batch(BatchProtocol):
     def __init__(
         self,
         batch_dict: dict
-                    | BatchProtocol
-                    | Sequence[dict | BatchProtocol]
-                    | np.ndarray
-                    | None = None,
+        | BatchProtocol
+        | Sequence[dict | BatchProtocol]
+        | np.ndarray
+        | None = None,
         copy: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -950,10 +950,10 @@ class Batch(BatchProtocol):
                 if isinstance(value, Batch) and len(value.get_keys()) == 0:
                     continue
                 try:
-                    self.__dict__[key][sum_lens[i]: sum_lens[i + 1]] = value
+                    self.__dict__[key][sum_lens[i] : sum_lens[i + 1]] = value
                 except KeyError:
                     self.__dict__[key] = create_value(value, sum_lens[-1], stack=False)
-                    self.__dict__[key][sum_lens[i]: sum_lens[i + 1]] = value
+                    self.__dict__[key][sum_lens[i] : sum_lens[i + 1]] = value
 
     def cat_(self, batches: BatchProtocol | Sequence[dict | BatchProtocol]) -> None:
         if isinstance(batches, BatchProtocol | dict):
@@ -1188,7 +1188,7 @@ class Batch(BatchProtocol):
             if merge_last and idx + size + size >= length:
                 yield self[indices[idx:]]
                 break
-            yield self[indices[idx: idx + size]]
+            yield self[indices[idx : idx + size]]
 
     @overload
     def apply_values_transform(

--- a/tianshou/data/types.py
+++ b/tianshou/data/types.py
@@ -9,10 +9,6 @@ from tianshou.data.batch import BatchProtocol, TArr
 TNestedDictValue = np.ndarray | dict[str, "TNestedDictValue"]
 
 
-d: dict[str, TNestedDictValue] = {"a": {"b": np.array([1, 2, 3])}}
-d["c"] = np.array([1, 2, 3])
-
-
 class ObsBatchProtocol(BatchProtocol, Protocol):
     """Observations of an environment that a policy can turn into actions.
 
@@ -62,6 +58,8 @@ class ActStateBatchProtocol(ActBatchProtocol, Protocol):
     """Contains action and state (which can be None), useful for policies that can support RNNs."""
 
     state: dict | BatchProtocol | np.ndarray | None
+    """Hidden state of RNNs, or None if not using RNNs. Used for recurrent policies.
+     At the moment support for recurrent is experimental!"""
 
 
 class ModelOutputBatchProtocol(ActStateBatchProtocol, Protocol):
@@ -121,7 +119,7 @@ class QuantileRegressionBatchProtocol(ModelOutputBatchProtocol, Protocol):
 
 
 class ImitationBatchProtocol(ActBatchProtocol, Protocol):
-    """Similar to other batches, but contains imitation_logits and q_value fields."""
+    """Similar to other batches, but contains `imitation_logits` and `q_value` fields."""
 
     state: dict | Batch | np.ndarray | None
     q_value: torch.Tensor

--- a/tianshou/evaluation/launcher.py
+++ b/tianshou/evaluation/launcher.py
@@ -27,6 +27,8 @@ class JoblibConfig:
 
 
 class ExpLauncher(ABC):
+    """Base interface for launching multiple experiments simultaneously."""
+
     def __init__(
         self,
         experiment_runner: Callable[
@@ -34,11 +36,13 @@ class ExpLauncher(ABC):
             InfoStats | None,
         ] = lambda exp: exp.run().trainer_result,
     ):
-        """:param experiment_runner: can be used to override the default way in which an experiment is executed.
-        Can be useful e.g., if one wants to use the high-level interfaces to setup an experiment (or an experiment
-        collection) and tinker with it prior to execution. This need often arises when prototyping with mechanisms
-        that are not yet supported by the high-level interfaces.
-        Passing this allows arbitrary things to happen during experiment execution, so use it with caution!
+        """
+        :param experiment_runner: determines how an experiment is to be executed.
+            Overriding the default can be useful, e.g., for using high-level interfaces
+            to set up an experiment (or an experiment collection) and tinkering with it prior to execution.
+            This need often arises when prototyping with mechanisms that are not yet supported by
+            the high-level interfaces.
+            Allows arbitrary things to happen during experiment execution, so use it with caution!.
         """
         self.experiment_runner = experiment_runner
 
@@ -112,6 +116,7 @@ class JoblibExpLauncher(ExpLauncher):
         super().__init__(experiment_runner=experiment_runner)
         self.joblib_cfg = copy(joblib_cfg) if joblib_cfg is not None else JoblibConfig()
         # Joblib's backend is hard-coded to loky since the threading backend produces different results
+        # TODO: fix this
         if self.joblib_cfg.backend != "loky":
             log.warning(
                 f"Ignoring the user provided joblib backend {self.joblib_cfg.backend} and using loky instead. "

--- a/tianshou/highlevel/agent.py
+++ b/tianshou/highlevel/agent.py
@@ -200,6 +200,7 @@ class OnPolicyAgentFactory(AgentFactory, ABC):
             batch_size=sampling_config.batch_size,
             step_per_collect=sampling_config.step_per_collect,
             save_best_fn=policy_persistence.get_save_best_fn(world),
+            save_checkpoint_fn=policy_persistence.get_save_checkpoint_fn(world),
             logger=world.logger,
             test_in_train=False,
             train_fn=train_fn,

--- a/tianshou/highlevel/agent.py
+++ b/tianshou/highlevel/agent.py
@@ -125,15 +125,6 @@ class AgentFactory(ABC, ToStringMixin):
         if reset_collectors:
             train_collector.reset()
             test_collector.reset()
-
-        if self.sampling_config.start_timesteps > 0:
-            log.info(
-                f"Collecting {self.sampling_config.start_timesteps} initial environment steps before training (random={self.sampling_config.start_timesteps_random})",
-            )
-            train_collector.collect(
-                n_step=self.sampling_config.start_timesteps,
-                random=self.sampling_config.start_timesteps_random,
-            )
         return train_collector, test_collector
 
     def set_policy_wrapper_factory(

--- a/tianshou/highlevel/env.py
+++ b/tianshou/highlevel/env.py
@@ -361,11 +361,11 @@ class EnvPoolFactory:
 
 
 class EnvFactory(ToStringMixin, ABC):
-    """Main interface for the creation of environments (in various forms)."""
-
     def __init__(self, venv_type: VectorEnvType):
-        """:param venv_type: the type of vectorized environment to use for train and test environments.
-        watch environments are always created as dummy environments.
+        """Main interface for the creation of environments (in various forms).
+
+        :param venv_type: the type of vectorized environment to use for train and test environments.
+            `WATCH` environments are always created as `DUMMY` vector environments.
         """
         self.venv_type = venv_type
 
@@ -377,7 +377,8 @@ class EnvFactory(ToStringMixin, ABC):
         """Create vectorized environments.
 
         :param num_envs: the number of environments
-        :param mode: the mode for which to create. In `WATCH` mode the resulting venv will always be of type `DUMMY` with a single env.
+        :param mode: the mode for which to create.
+            In `WATCH` mode the resulting venv will always be of type `DUMMY` with a single env.
 
         :return: the vectorized environments
         """
@@ -437,9 +438,7 @@ class EnvFactoryRegistered(EnvFactory):
         :param render_mode_train: the render mode to use for training environments
         :param render_mode_test: the render mode to use for test environments
         :param render_mode_watch: the render mode to use for environments that are used to watch agent performance
-        :param make_kwargs: additional keyword arguments to pass on to `gymnasium.make`.
-            If envpool is used, the gymnasium parameters will be appropriately translated for use with
-            `envpool.make_gymnasium`.
+        :param make_kwargs: additional keyword arguments to pass on to `gymnasium.make`. If envpool is used, the gymnasium parameters will be appropriately translated for use with `envpool.make_gymnasium`.
         """
         super().__init__(venv_type)
         self.task = task

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -1,17 +1,18 @@
 """The experiment module provides high-level interfaces for setting up and running reinforcement learning experiments.
 
 The main entry points are:
- - `ExperimentConfig`: a dataclass for configuring the experiment. The configuration is
-    different from RL specific configuration (such as policy and trainer parameters)
-    and only pertains to configuration that is common to all experiments.
-- `Experiment`: represents a reinforcement learning experiment.
-    It is composed of configuration and factory objects, is lightweight and serializable.
-    An instance of `Experiment` is usually saved as a pickle file after an experiment is executed.
-- `ExperimentBuilder`: a helper class for creating experiments. It contains a lot of defaults
-    and allows for easy customization of the experiment setup.
-- `ExperimentCollection`: a shallow wrapper around a list of experiments providing a
-    simple interface for running them with a launcher. Useful for running multiple experiments in parallel, in
-    particular, for the important case of running experiments that only differ in their random seeds.
+
+* :class:`ExperimentConfig`: a dataclass for configuring the experiment. The configuration is
+  different from RL specific configuration (such as policy and trainer parameters)
+  and only pertains to configuration that is common to all experiments.
+* :class:`Experiment`: represents a reinforcement learning experiment.
+  It is composed of configuration and factory objects, is lightweight and serializable.
+  An instance of `Experiment` is usually saved as a pickle file after an experiment is executed.
+* :class:`ExperimentBuilder`: a helper class for creating experiments. It contains a lot of defaults
+  and allows for easy customization of the experiment setup.
+* :class:`ExperimentCollection`: a shallow wrapper around a list of experiments providing a
+  simple interface for running them with a launcher. Useful for running multiple experiments in parallel, in
+  particular, for the important case of running experiments that only differ in their random seeds.
 
 Various implementations of the `ExperimentBuilder` are provided for each of the algorithms supported by Tianshou.
 """
@@ -77,7 +78,6 @@ from tianshou.highlevel.optim import (
     DEFAULT_OPTIM_FACTORY_PARAMS,
     DefaultOptimFactoryParams,
     OptimizerFactory,
-    OptimizerFactoryAdam,
     OptimizerFactoryDefault,
 )
 from tianshou.highlevel.params.policy_params import (
@@ -169,11 +169,11 @@ class Experiment(ToStringMixin):
 
     The main entry points are:
 
-    1. `run`: runs the experiment and returns the results
-    2. `create_experiment_world`: creates the world object for the experiment, which contains all relevant instances.
+    1. :meth:`run`: runs the experiment and returns the results
+    2. :meth:`create_experiment_world`: creates the world object for the experiment, which contains all relevant instances.
         Useful for setting up the experiment and running it in a more custom way.
 
-    The methods `save` and `from_directory` can be used to store and restore experiments.
+    The methods :meth:`save` and :meth:`from_directory` can be used to store and restore experiments.
     """
 
     LOG_FILENAME = "log.txt"
@@ -313,7 +313,7 @@ class Experiment(ToStringMixin):
             full_config["experiment_config"] = asdict(self.config)
             full_config["sampling_config"] = asdict(self.sampling_config)
             with suppress(AttributeError):
-                full_config["policy_params"] = asdict(self.agent_factory.params) # type: ignore
+                full_config["policy_params"] = asdict(self.agent_factory.params)  # type: ignore
 
             logger: TLogger
             if use_persistence:
@@ -463,7 +463,13 @@ class ExperimentCollection:
 
 
 class ExperimentBuilder:
-    OPTIM_FACTORY_DEFAULT_CLS = OptimizerFactoryAdam
+    """A helper class (following the builder pattern) for creating experiments.
+
+    It contains a lot of defaults for the setup which can be adjusted using the
+    various `with_` methods. For example, the default optimizer is Adam, but can be
+    adjusted using :meth:`with_optim_factory`. Moreover, for simply configuring the default
+    optimizer instead of using a different one, one can use :meth:`with_optim_factory_default`.
+    """
 
     def __init__(
         self,
@@ -471,14 +477,7 @@ class ExperimentBuilder:
         experiment_config: ExperimentConfig | None = None,
         sampling_config: SamplingConfig | None = None,
     ):
-        """A helper class (following the builder pattern) for creating experiments.
-
-        It contains a lot of defaults for the setup which can be adjusted using the
-        various `with_` methods. For example, the default optimizer is Adam, but can be
-        adjusted using `with_optim_factory`. Moreover, for simply configuring the default
-        optimizer instead of using a different one, one can use `with_optim_factory_default`.
-
-        :param env_factory: controls how environments are to be created.
+        """:param env_factory: controls how environments are to be created.
         :param experiment_config: the configuration for the experiment. If None, will use the default values
             of `ExperimentConfig`.
         :param sampling_config: the sampling configuration to use. If None, will use the default values

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -1,11 +1,33 @@
+"""The experiment module provides high-level interfaces for setting up and running reinforcement learning experiments.
+
+The main entry points are:
+ - `ExperimentConfig`: a dataclass for configuring the experiment. The configuration is
+    different from RL specific configuration (such as policy and trainer parameters)
+    and only pertains to configuration that is common to all experiments.
+- `Experiment`: represents a reinforcement learning experiment.
+    It is composed of configuration and factory objects, is lightweight and serializable.
+    An instance of `Experiment` is usually saved as a pickle file after an experiment is executed.
+- `ExperimentBuilder`: a helper class for creating experiments. It contains a lot of defaults
+    and allows for easy customization of the experiment setup.
+- `ExperimentCollection`: a shallow wrapper around a list of experiments providing a
+    simple interface for running them with a launcher. Useful for running multiple experiments in parallel, in
+    particular, for the important case of running experiments that only differ in their random seeds.
+
+Various implementations of the `ExperimentBuilder` are provided for each of the algorithms supported by Tianshou.
+"""
+
 import os
 import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
+from contextlib import suppress
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Self, Union, cast
+from typing import TYPE_CHECKING, Literal, Self, Union, Unpack
+
+if TYPE_CHECKING:
+    from tianshou.evaluation.launcher import ExpLauncher, RegisteredExpLauncher
 
 import numpy as np
 import torch
@@ -51,7 +73,13 @@ from tianshou.highlevel.module.critic import (
 )
 from tianshou.highlevel.module.intermediate import IntermediateModuleFactory
 from tianshou.highlevel.module.special import ImplicitQuantileNetworkFactory
-from tianshou.highlevel.optim import OptimizerFactory, OptimizerFactoryAdam
+from tianshou.highlevel.optim import (
+    DEFAULT_OPTIM_FACTORY_PARAMS,
+    DefaultOptimFactoryParams,
+    OptimizerFactory,
+    OptimizerFactoryAdam,
+    OptimizerFactoryDefault,
+)
 from tianshou.highlevel.params.policy_params import (
     A2CParams,
     DDPGParams,
@@ -79,13 +107,10 @@ from tianshou.highlevel.trainer import (
 )
 from tianshou.highlevel.world import World
 from tianshou.policy import BasePolicy
-from tianshou.utils import LazyLogger, deprecation, logging
+from tianshou.utils import LazyLogger, logging
 from tianshou.utils.logging import datetime_tag
 from tianshou.utils.net.common import ModuleType
 from tianshou.utils.string import ToStringMixin
-
-if TYPE_CHECKING:
-    from tianshou.evaluation.launcher import ExpLauncher, RegisteredExpLauncher
 
 log = logging.getLogger(__name__)
 
@@ -125,7 +150,12 @@ class ExperimentResult:
     """Contains the results of an experiment."""
 
     world: World
-    """contains all the essential instances of the experiment"""
+    """The `World` contains all the essential instances of the experiment.
+    Can also be created via `Experiment.create_experiment_world` for more custom setups, see docstring there.
+
+    Note: it is typically not serializable, so it is not stored in the experiment pickle, and shouldn't be
+    sent across processes, meaning also that `ExperimentResult` itself is typically not serializable.
+    """
     trainer_result: InfoStats | None
     """dataclass of results as returned by the trainer (if any)"""
 
@@ -136,6 +166,14 @@ class Experiment(ToStringMixin):
     An experiment is composed only of configuration and factory objects, which themselves
     should be designed to contain only configuration. Therefore, experiments can easily
     be stored/pickled and later restored without any problems.
+
+    The main entry points are:
+
+    1. `run`: runs the experiment and returns the results
+    2. `create_experiment_world`: creates the world object for the experiment, which contains all relevant instances.
+        Useful for setting up the experiment and running it in a more custom way.
+
+    The methods `save` and `from_directory` can be used to store and restore experiments.
     """
 
     LOG_FILENAME = "log.txt"
@@ -204,43 +242,39 @@ class Experiment(ToStringMixin):
         with open(path, "wb") as f:
             pickle.dump(self, f)
 
-    def run(
+    def create_experiment_world(
         self,
-        run_name: str | None = None,
+        override_experiment_name: str | Literal["DATETIME_TAG"] | None = None,
         logger_run_id: str | None = None,
         raise_error_on_dirname_collision: bool = True,
-        **kwargs: dict[str, Any],
-    ) -> ExperimentResult:
-        """Run the experiment and return the results.
+        reset_collectors: bool = True,
+    ) -> World:
+        """Creates the world object for the experiment.
 
-        :param run_name: Defines a name for this run of the experiment, which determines
-            the subdirectory (within the persistence base directory) where all results will be saved.
-            If None, the experiment's name will be used.
-            The name may contain path separators (i.e. `os.path.sep`, as used by `os.path.join`), in which case
-            a nested directory structure will be created.
-        :param logger_run_id: Run identifier to use for logger initialization/resumption (applies when
-            using wandb, in particular).
-        :param raise_error_on_dirname_collision: set to `False` e.g., when continuing a previously executed
-            experiment with the same name.
-        :param kwargs: for backward compatibility with old parameter names only
-        :return:
+        The world object contains all relevant instances for the experiment,
+        such as environments, policy, collectors, etc.
+        This method is the main entrypoint for users who don't want to use `run` directly. A common use case
+        is that some configuration or custom logic should happen before the training loop starts, but one
+        still wants to use the convenience of high-level interfaces for setting up the experiment.
+
+        :param override_experiment_name: whether to override the experiment name in the resulting `World`.
+            Passing `DATETIME_TAG` will use a name containing the current date and time.
+        :param logger_run_id: Run identifier to use for logger initialization/resumption.
+        :param raise_error_on_dirname_collision: whether to raise an error on collisions when creating the
+            persistence directory. Only takes effect if persistence is enabled. Set to `False` e.g., when continuing
+            a previously executed experiment with the same `persistence_base_dir` and name.
+        :param reset_collectors: whether to reset the collectors before training starts.
+            Setting to `False` can be useful when continuing training from a previous run with restored collectors,
+            or for adding custom logic before training starts.
         """
-        # backward compatibility
-        _experiment_name = kwargs.pop("experiment_name", None)
-        if _experiment_name is not None:
-            run_name = cast(str, _experiment_name)
-            deprecation(
-                "Parameter run_name should now be used instead of experiment_name. "
-                "Support for experiment_name will be removed in the future.",
-            )
-        assert len(kwargs) == 0, f"Received unexpected arguments: {kwargs}"
-
-        if run_name is None:
-            run_name = self.name
+        if override_experiment_name is not None:
+            if override_experiment_name == "DATETIME_TAG":
+                override_experiment_name = datetime_tag()
+            self.name = override_experiment_name
 
         # initialize persistence directory
         use_persistence = self.config.persistence_enabled
-        persistence_dir = os.path.join(self.config.persistence_base_dir, run_name)
+        persistence_dir = os.path.join(self.config.persistence_base_dir, self.name)
         if use_persistence:
             os.makedirs(persistence_dir, exist_ok=not raise_error_on_dirname_collision)
 
@@ -249,7 +283,7 @@ class Experiment(ToStringMixin):
             enabled=use_persistence and self.config.log_file_enabled,
         ):
             # log initial information
-            log.info(f"Running experiment (name='{run_name}'):\n{self.pprints()}")
+            log.info(f"Running experiment (name='{self.name}'):\n{self.pprints()}")
             log.info(f"Working directory: {os.getcwd()}")
 
             self._set_seed()
@@ -276,11 +310,16 @@ class Experiment(ToStringMixin):
             # initialize logger
             full_config = self._build_config_dict()
             full_config.update(envs.info())
+            full_config["experiment_config"] = asdict(self.config)
+            full_config["sampling_config"] = asdict(self.sampling_config)
+            with suppress(AttributeError):
+                full_config["policy_params"] = asdict(self.agent_factory.params) # type: ignore
+
             logger: TLogger
             if use_persistence:
                 logger = self.logger_factory.create_logger(
                     log_dir=persistence_dir,
-                    experiment_name=run_name,
+                    experiment_name=self.name,
                     run_id=logger_run_id,
                     config_dict=full_config,
                 )
@@ -294,6 +333,7 @@ class Experiment(ToStringMixin):
             train_collector, test_collector = self.agent_factory.create_train_test_collector(
                 policy,
                 envs,
+                reset_collectors=reset_collectors,
             )
 
             # create context object with all relevant instances (except trainer; added later)
@@ -315,23 +355,74 @@ class Experiment(ToStringMixin):
                     self.config.device,
                 )
 
-            # train policy
-            log.info("Starting training")
-            trainer_result: InfoStats | None = None
             if self.config.train:
                 trainer = self.agent_factory.create_trainer(world, policy_persistence)
                 world.trainer = trainer
-                trainer_result = trainer.run()
+
+        return world
+
+    def run(
+        self,
+        run_name: str | Literal["DATETIME_TAG"] | None = None,
+        logger_run_id: str | None = None,
+        raise_error_on_dirname_collision: bool = True,
+    ) -> ExperimentResult:
+        """Run the experiment and return the results.
+
+        :param run_name: if not None, will adjust the current instance's `name` name attribute.
+            The name corresponds to the directory (within the logging
+            directory) where all results associated with the experiment will be saved.
+            The name may contain path separators (i.e. `os.path.sep`, as used by `os.path.join`), in which case
+            a nested directory structure will be created.
+            If "DATETIME_TAG" is passed, use a name containing the current date and time. This option
+            is useful for preventing file-name collisions if a single experiment is executed repeatedly.
+        :param logger_run_id: Run identifier to use for logger initialization/resumption (applies when
+            using wandb, in particular).
+        :param raise_error_on_dirname_collision: set to `False` e.g., when continuing a previously executed
+            experiment with the same name.
+        :return:
+        """
+        world = self.create_experiment_world(
+            override_experiment_name=run_name,
+            logger_run_id=logger_run_id,
+            raise_error_on_dirname_collision=raise_error_on_dirname_collision,
+        )
+
+        persistence_dir = world.persist_directory
+        use_persistence = self.config.persistence_enabled
+
+        with logging.FileLoggerContext(
+            os.path.join(persistence_dir, self.LOG_FILENAME),
+            enabled=use_persistence and self.config.log_file_enabled,
+        ):
+            trainer_result: InfoStats | None = None
+            if self.config.train:
+                # prefilling buffers with random actions
+                if self.sampling_config.start_timesteps > 0:
+                    log.info(
+                        f"Collecting {self.sampling_config.start_timesteps} initial environment "
+                        f"steps before training (random={self.sampling_config.start_timesteps_random})",
+                    )
+                    world.train_collector.collect(
+                        n_step=self.sampling_config.start_timesteps,
+                        random=self.sampling_config.start_timesteps_random,
+                    )
+
+                log.info("Starting training")
+                assert world.trainer is not None
+                world.trainer.run()
+                if use_persistence:
+                    world.logger.finalize()
                 log.info(f"Training result:\n{pformat(trainer_result)}")
 
             # watch agent performance
             if self.config.watch:
-                assert envs.watch_env is not None
+                assert world.envs.watch_env is not None
                 log.info("Watching agent performance")
                 self._watch_agent(
                     self.config.watch_num_episodes,
-                    policy,
-                    envs.watch_env,
+                    world.policy,
+                    world.envs.watch_env,
                     self.config.watch_render,
                 )
 
@@ -372,19 +463,30 @@ class ExperimentCollection:
 
 
 class ExperimentBuilder:
+    OPTIM_FACTORY_DEFAULT_CLS = OptimizerFactoryAdam
+
     def __init__(
         self,
         env_factory: EnvFactory,
         experiment_config: ExperimentConfig | None = None,
         sampling_config: SamplingConfig | None = None,
     ):
-        if experiment_config is None:
-            experiment_config = ExperimentConfig()
-        if sampling_config is None:
-            sampling_config = SamplingConfig()
-        self._config = experiment_config
+        """A helper class (following the builder pattern) for creating experiments.
+
+        It contains a lot of defaults for the setup which can be adjusted using the
+        various `with_` methods. For example, the default optimizer is Adam, but can be
+        adjusted using `with_optim_factory`. Moreover, for simply configuring the default
+        optimizer instead of using a different one, one can use `with_optim_factory_default`.
+
+        :param env_factory: controls how environments are to be created.
+        :param experiment_config: the configuration for the experiment. If None, will use the default values
+            of `ExperimentConfig`.
+        :param sampling_config: the sampling configuration to use. If None, will use the default values
+            of `SamplingConfig`.
+        """
+        self._config = experiment_config or ExperimentConfig()
         self._env_factory = env_factory
-        self._sampling_config = sampling_config
+        self._sampling_config = sampling_config or SamplingConfig()
         self._logger_factory: LoggerFactory | None = None
         self._optim_factory: OptimizerFactory | None = None
         self._policy_wrapper_factory: PolicyWrapperFactory | None = None
@@ -443,18 +545,15 @@ class ExperimentBuilder:
 
     def with_optim_factory_default(
         self,
-        betas: tuple[float, float] = (0.9, 0.999),
-        eps: float = 1e-08,
-        weight_decay: float = 0,
+        **kwargs: Unpack[DefaultOptimFactoryParams],
     ) -> Self:
-        """Configures the use of the default optimizer, Adam, with the given parameters.
+        """Configures the use of the default optimizer, with the given parameters.
 
-        :param betas: coefficients used for computing running averages of gradient and its square
-        :param eps: term added to the denominator to improve numerical stability
-        :param weight_decay: weight decay (L2 penalty)
+        :param kwargs: the parameters to use for the optimizer, see `DefaultOptimFactoryParams`.
         :return: the builder
         """
-        self._optim_factory = OptimizerFactoryAdam(betas=betas, eps=eps, weight_decay=weight_decay)
+        default_optim_params: DefaultOptimFactoryParams = {**DEFAULT_OPTIM_FACTORY_PARAMS, **kwargs}
+        self._optim_factory = OptimizerFactoryDefault(**default_optim_params)
         return self
 
     def with_epoch_train_callback(self, callback: EpochTrainCallback) -> Self:
@@ -505,7 +604,7 @@ class ExperimentBuilder:
 
     def _get_optim_factory(self) -> OptimizerFactory:
         if self._optim_factory is None:
-            return OptimizerFactoryAdam()
+            return OptimizerFactoryDefault()
         else:
             return self._optim_factory
 
@@ -531,7 +630,13 @@ class ExperimentBuilder:
     def build_seeded_collection(self, num_experiments: int) -> ExperimentCollection:
         """Creates a collection of experiments with non-overlapping random seeds, starting from the configured seed.
 
-        Each experiment in the collection will have a unique name that is created from the original experiment name and the seeds used.
+        Useful for performing statistically meaningful evaluations of an algorithm's performance.
+        The `rliable` recommendation is to use at least 5 experiments for computing quantities such as the
+        interquantile mean and performance profiles. See the usage in example scripts
+        like `examples/mujoco/mujoco_ppo_hl_multi.py`.
+
+        Each experiment in the collection will have a unique name created from the original experiment name
+        and the seeds used.
         """
         num_train_envs = self.sampling_config.num_train_envs
 
@@ -553,7 +658,7 @@ class _BuilderMixinActorFactory(ActorFutureProviderProtocol):
         self._actor_factory: ActorFactory | None = None
 
     def with_actor_factory(self, actor_factory: ActorFactory) -> Self:
-        """Allows to customize the actor component via the specification of a factory.
+        """Allows customizing the actor component via the specification of a factory.
 
         If this function is not called, a default actor factory (with default parameters) will be used.
 

--- a/tianshou/highlevel/optim.py
+++ b/tianshou/highlevel/optim.py
@@ -45,6 +45,8 @@ class OptimizerFactoryTorch(OptimizerFactory):
 
 
 class OptimizerFactoryAdam(OptimizerFactory):
+    # Note: currently used as default optimizer
+    # values should be kept in sync with `ExperimentBuilder.with_optim_factory_default`
     def __init__(
         self,
         betas: tuple[float, float] = (0.9, 0.999),

--- a/tianshou/highlevel/params/noise.py
+++ b/tianshou/highlevel/params/noise.py
@@ -17,8 +17,8 @@ class NoiseFactoryMaxActionScaledGaussian(NoiseFactory):
 
         This factory can only be applied to continuous action spaces.
 
-        :param std_fraction: fraction (between 0 and 1) of the maximum action value that shall
-        be used as the standard deviation
+        :param std_fraction: fraction (between 0 and 1) of the maximum action value that
+            shall be used as the standard deviation
         """
         self.std_fraction = std_fraction
 

--- a/tianshou/highlevel/persistence.py
+++ b/tianshou/highlevel/persistence.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
@@ -128,3 +129,25 @@ class PolicyPersistence:
             self.persist(pol, world)
 
         return save_best_fn
+
+    def get_save_checkpoint_fn(self, world: World) -> Callable[[int, int, int], str]:
+        def save_checkpoint_fn(epoch: int, env_step: int, gradient_step: int) -> str:
+            if not self.enabled:
+                return None
+            path = Path(self.mode.get_filename())
+            path_with_epoch = path.with_stem(f"{path.stem}_epoch_{epoch}")
+            path = world.persist_path(path_with_epoch.name)
+            match self.mode:
+                case self.Mode.POLICY_STATE_DICT:
+                    log.info(f"Saving policy state dictionary in {path}")
+                    torch.save(world.policy.state_dict(), path)
+                case self.Mode.POLICY:
+                    log.info(f"Saving policy object in {path}")
+                    torch.save(world.policy, path)
+                case _:
+                    raise NotImplementedError
+            if self.additional_persistence is not None:
+                self.additional_persistence.persist(PersistEvent.PERSIST_POLICY, world)
+            return path
+
+        return save_checkpoint_fn

--- a/tianshou/highlevel/persistence.py
+++ b/tianshou/highlevel/persistence.py
@@ -76,7 +76,6 @@ class PolicyPersistence:
         def get_filename(self) -> str:
             return self.value + ".pt"
 
-
     def __init__(
         self,
         additional_persistence: Persistence | None = None,

--- a/tianshou/highlevel/persistence.py
+++ b/tianshou/highlevel/persistence.py
@@ -76,6 +76,7 @@ class PolicyPersistence:
         def get_filename(self) -> str:
             return self.value + ".pt"
 
+
     def __init__(
         self,
         additional_persistence: Persistence | None = None,
@@ -130,10 +131,11 @@ class PolicyPersistence:
 
         return save_best_fn
 
-    def get_save_checkpoint_fn(self, world: World) -> Callable[[int, int, int], str]:
+    def get_save_checkpoint_fn(self, world: World) -> Callable[[int, int, int], str] | None:
+        if not self.enabled:
+            return None
+
         def save_checkpoint_fn(epoch: int, env_step: int, gradient_step: int) -> str:
-            if not self.enabled:
-                return None
             path = Path(self.mode.get_filename())
             path_with_epoch = path.with_stem(f"{path.stem}_epoch_{epoch}")
             path = world.persist_path(path_with_epoch.name)

--- a/tianshou/highlevel/trainer.py
+++ b/tianshou/highlevel/trainer.py
@@ -135,8 +135,9 @@ class EpochStopCallbackRewardThreshold(EpochStopCallback):
     """
 
     def __init__(self, threshold: float | None = None):
-        """:param threshold: the reward threshold beyond which to stop training.
-        If it is None, use threshold given by the environment, i.e. `env.spec.reward_threshold`.
+        """
+        :param threshold: the reward threshold beyond which to stop training.
+            If it is None, will use threshold specified by the environment, i.e. `env.spec.reward_threshold`.
         """
         self.threshold = threshold
 

--- a/tianshou/utils/logger/base.py
+++ b/tianshou/utils/logger/base.py
@@ -153,6 +153,9 @@ class BaseLogger(ABC):
         :return: a dict containing the logged data.
         """
 
+    def finalize(self) -> None:
+        """Finalize the logger, e.g. close the file handler."""
+
 
 class LazyLogger(BaseLogger):
     """A logger that does nothing. Used as the placeholder in trainer."""


### PR DESCRIPTION
Gives the user the possibility to extract the `World` from a configured `Experiment`. This required moving the initial rollout (according to `start_timesteps`) from the `AgentFactory` to `Experiment.run`. But since it was only ever used there, this change is essentially backwards compatible

I also enhanced documentation. `__init__` docstrings were previously not rendered and there were some formatting errors in them, hence the changes there.