### PR TITLE
Fix: Policy parameter action_scaling was not correctly transformed (high-level API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,13 @@
     - `DataclassPPrintMixin` now supports outputting a string, not just printing the pretty repr. #1141
 
 ### Fixes
-- `CriticFactoryReuseActor`: Enable the Critic flag `apply_preprocess_net_to_obs_only` for continuous critics, 
-  fixing the case where we want to reuse an actor's preprocessing network for the critic (affects usages
-  of the experiment builder method `with_critic_factory_use_actor` with continuous environments) #1128
+- `highlevel`:
+  - `CriticFactoryReuseActor`: Enable the Critic flag `apply_preprocess_net_to_obs_only` for continuous critics, 
+    fixing the case where we want to reuse an actor's preprocessing network for the critic (affects usages
+    of the experiment builder method `with_critic_factory_use_actor` with continuous environments) #1128
+  - Policy parameter `action_scaling` value `"default"` was not correctly transformed to a Boolean value for 
+    algorithms SAC, DDPG, TD3 and REDQ. The value `"default"` being truthy caused action scaling to be enabled
+    even for discrete action spaces. #1191
 - `atari_network.DQN`:
   - Fix constructor input validation #1128
   - Fix `output_dim` not being set if `features_only`=True and `output_dim_added_layer` is not None #1128

--- a/tianshou/highlevel/params/policy_params.py
+++ b/tianshou/highlevel/params/policy_params.py
@@ -289,7 +289,7 @@ class ParamsMixinActionScaling(GetParamTransformersProtocol):
     """
 
     def _get_param_transformers(self) -> list[ParamTransformer]:
-        return []
+        return [ParamTransformerActionScaling("action_scaling")]
 
 
 @dataclass
@@ -335,7 +335,6 @@ class PGParams(Params, ParamsMixinActionScaling, ParamsMixinLearningRateWithSche
         transformers = super()._get_param_transformers()
         transformers.extend(ParamsMixinActionScaling._get_param_transformers(self))
         transformers.extend(ParamsMixinLearningRateWithScheduler._get_param_transformers(self))
-        transformers.append(ParamTransformerActionScaling("action_scaling"))
         transformers.append(ParamTransformerDistributionFunction("dist_fn"))
         return transformers
 


### PR DESCRIPTION
Policy parameter `action_scaling` value `"default"` was not correctly transformed to a Boolean value for algorithms SAC, DDPG, TD3 and REDQ. The value `"default"` being truthy caused action scaling to be enabled even for discrete action spaces.

- [X] I have added the correct label(s) to this Pull Request or linked the relevant issue(s)
- [X] I have provided a description of the changes in this Pull Request
- [X] I have added documentation for my changes and have listed relevant changes in CHANGELOG.md
- [ ] If applicable, I have added tests to cover my changes.
- [X] I have reformatted the code using `poe format` 
- [X] I have checked style and types with `poe lint` and `poe type-check`
- [ ] (Optional) I ran tests locally with `poe test` 
(or a subset of them with `poe test-reduced`) ,and they pass
- [ ] (Optional) I have tested that documentation builds correctly with `poe doc-build`