### PR TITLE
Support computing custom scores and terminating/saving based on them in BaseTrainer

### DIFF
--- a/tianshou/data/stats.py
+++ b/tianshou/data/stats.py
@@ -56,6 +56,8 @@ class InfoStats(DataclassPPrintMixin):
 
     gradient_step: int
     """The total gradient step."""
+    best_score: float
+    """The best score over the test results."""
     best_reward: float
     """The best reward over the test results."""
     best_reward_std: float

--- a/tianshou/data/stats.py
+++ b/tianshou/data/stats.py
@@ -57,7 +57,7 @@ class InfoStats(DataclassPPrintMixin):
     gradient_step: int
     """The total gradient step."""
     best_score: float
-    """The best score over the test results."""
+    """The best score over the test results. The one with the highest score will be considered the best model."""
     best_reward: float
     """The best reward over the test results."""
     best_reward_std: float

--- a/tianshou/trainer/base.py
+++ b/tianshou/trainer/base.py
@@ -73,6 +73,7 @@ class BaseTrainer(ABC):
     :param test_fn: a hook called at the beginning of testing in each
         epoch. It can be used to perform custom additional operations, with the
         signature ``f(num_epoch: int, step_idx: int) -> None``.
+    :param evaluate_test_fn: Calculate the test batch performance score to determine whether it is the best model
     :param save_best_fn: a hook called when the undiscounted average mean
         reward in evaluation phase gets better, with the signature
         ``f(policy: BasePolicy) -> None``.
@@ -164,6 +165,7 @@ class BaseTrainer(ABC):
         train_fn: Callable[[int, int], None] | None = None,
         test_fn: Callable[[int, int | None], None] | None = None,
         stop_fn: Callable[[float], bool] | None = None,
+        evaluate_test_fn: Callable[[CollectStats], float] | None = None,
         save_best_fn: Callable[[BasePolicy], None] | None = None,
         save_checkpoint_fn: Callable[[int, int, int], str] | None = None,
         resume_from_log: bool = False,
@@ -185,6 +187,7 @@ class BaseTrainer(ABC):
         self.logger = logger
         self.start_time = time.time()
         self.stat: defaultdict[str, MovAvg] = defaultdict(MovAvg)
+        self.best_score = 0.0
         self.best_reward = 0.0
         self.best_reward_std = 0.0
         self.start_epoch = 0
@@ -210,6 +213,7 @@ class BaseTrainer(ABC):
         self.train_fn = train_fn
         self.test_fn = test_fn
         self.stop_fn = stop_fn
+        self.evaluate_test_fn = evaluate_test_fn
         self.save_best_fn = save_best_fn
         self.save_checkpoint_fn = save_checkpoint_fn
 
@@ -273,6 +277,10 @@ class BaseTrainer(ABC):
                 test_result.returns_stat.mean,
                 test_result.returns_stat.std,
             )
+            if self.evaluate_test_fn:
+                self.best_score = self.evaluate_test_fn(test_result)
+            else:
+                self.best_score = self.best_reward
         if self.save_best_fn:
             self.save_best_fn(self.policy)
 
@@ -351,6 +359,7 @@ class BaseTrainer(ABC):
             start_time=self.start_time,
             policy_update_time=self.policy_update_time,
             gradient_step=self._gradient_step,
+            best_score=self.best_score,
             best_reward=self.best_reward,
             best_reward_std=self.best_reward_std,
             train_collector=self.train_collector,
@@ -384,17 +393,29 @@ class BaseTrainer(ABC):
         )
         assert test_stat.returns_stat is not None  # for mypy
         rew, rew_std = test_stat.returns_stat.mean, test_stat.returns_stat.std
-        if self.best_epoch < 0 or self.best_reward < rew:
+        if self.evaluate_test_fn:
+            score = self.evaluate_test_fn(test_stat)
+        else:
+            score = float(rew)
+        if self.best_epoch < 0 or self.best_score < score:
+            self.best_score = score
             self.best_epoch = self.epoch
             self.best_reward = float(rew)
             self.best_reward_std = rew_std
             if self.save_best_fn:
                 self.save_best_fn(self.policy)
-        log_msg = (
-            f"Epoch #{self.epoch}: test_reward: {rew:.6f} ± {rew_std:.6f},"
-            f" best_reward: {self.best_reward:.6f} ± "
-            f"{self.best_reward_std:.6f} in #{self.best_epoch}"
-        )
+        if self.evaluate_test_fn:
+            log_msg = (
+                f"Epoch #{self.epoch}: test_reward: {rew:.6f} ± {rew_std:.6f}, score: {score:.6f},"
+                f" best_reward: {self.best_reward:.6f} ± "
+                f"{self.best_reward_std:.6f}, score: {self.best_score:.6f} in #{self.best_epoch}"
+            )
+        else:
+            log_msg = (
+                f"Epoch #{self.epoch}: test_reward: {rew:.6f} ± {rew_std:.6f},"
+                f" best_reward: {self.best_reward:.6f} ± "
+                f"{self.best_reward_std:.6f} in #{self.best_epoch}"
+            )
         log.info(log_msg)
         if self.verbose:
             print(log_msg, flush=True)
@@ -506,6 +527,10 @@ class BaseTrainer(ABC):
                     should_stop_training = True
                     self.best_reward = test_result.returns_stat.mean
                     self.best_reward_std = test_result.returns_stat.std
+                    if self.evaluate_test_fn:
+                        self.best_score = self.evaluate_test_fn(test_result)
+                    else:
+                        self.best_score = self.best_reward
 
         return should_stop_training
 
@@ -562,6 +587,7 @@ class BaseTrainer(ABC):
                 start_time=self.start_time,
                 policy_update_time=self.policy_update_time,
                 gradient_step=self._gradient_step,
+                best_score=self.best_score,
                 best_reward=self.best_reward,
                 best_reward_std=self.best_reward_std,
                 train_collector=self.train_collector,

--- a/tianshou/trainer/base.py
+++ b/tianshou/trainer/base.py
@@ -216,9 +216,11 @@ class BaseTrainer(ABC):
         self.stop_fn = stop_fn
         self.compute_score_fn: Callable[[CollectStats], float]
         if compute_score_fn is None:
+
             def compute_score_fn(stat: CollectStats) -> float:
                 assert stat.returns_stat is not None  # for mypy
                 return stat.returns_stat.mean
+
         self.compute_score_fn = compute_score_fn
         self.save_best_fn = save_best_fn
         self.save_checkpoint_fn = save_checkpoint_fn

--- a/tianshou/trainer/base.py
+++ b/tianshou/trainer/base.py
@@ -214,9 +214,12 @@ class BaseTrainer(ABC):
         self.train_fn = train_fn
         self.test_fn = test_fn
         self.stop_fn = stop_fn
+        self.compute_score_fn: Callable[[CollectStats], float]
+        if compute_score_fn is None:
+            def compute_score_fn(stat: CollectStats) -> float:
+                assert stat.returns_stat is not None  # for mypy
+                return stat.returns_stat.mean
         self.compute_score_fn = compute_score_fn
-        if self.compute_score_fn is None:
-            self.compute_score_fn = lambda stat: stat.returns_stat.mean
         self.save_best_fn = save_best_fn
         self.save_checkpoint_fn = save_checkpoint_fn
 

--- a/tianshou/trainer/utils.py
+++ b/tianshou/trainer/utils.py
@@ -42,6 +42,7 @@ def gather_info(
     start_time: float,
     policy_update_time: float,
     gradient_step: int,
+    best_score: float,
     best_reward: float,
     best_reward_std: float,
     train_collector: BaseCollector | None = None,
@@ -75,6 +76,7 @@ def gather_info(
 
     return InfoStats(
         gradient_step=gradient_step,
+        best_score=best_score,
         best_reward=best_reward,
         best_reward_std=best_reward_std,
         train_step=train_collector.collect_step if train_collector is not None else 0,


### PR DESCRIPTION
This PR introduces a new concept into tianshou training: a `best_score`. It is computed from the appropriate `Stats` instance and always added to `InfoStats`.

## Breaking Changes:
- `InfoStats` has a new non-optional field `best_score`

## Background

Currently, tianshou uses the maximum average return to find the best model. But sometimes it may not meet user needs, for example, the average return only drops by 5%, but the standard deviation drops by 50%. The latter is generally considered to be more stable and better than the former.
