### PR TITLE
Fix DiscreteSACExperimentBuilder not exposing `with_actor_factory_default`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## Release 1.2.0
+## Unreleased
 
 ### Changes/Improvements
 
 - trainer:
     - Custom scoring now supported for selecting the best model. #1202
+- highlevel:
+    - `DiscreteSACExperimentBuilder`: Expose method `with_actor_factory_default` #1248 #1250
 
 ### Breaking Changes
 

--- a/docs/04_contributing/04_contributing.rst
+++ b/docs/04_contributing/04_contributing.rst
@@ -13,6 +13,17 @@ to install all relevant requirements in editable mode you can simply call
   $ poetry install --with dev
 
 
+Platform-Specific Configuration
+-------------------------------
+
+**Windows**:
+Since the repository contains symbolic links, make sure to set the following git configuration:
+
+  * Enable symlinks for this repository: `git config core.symlinks true`
+  * Enable developer mode to allow symlinks to be created: Search Start Menu for "Developer Settings" and enable "Developer Mode"
+  * Re-checkout the current git state: `git checkout .`
+
+
 PEP8 Code Style Check and Formatting
 ----------------------------------------
 

--- a/docs/04_contributing/04_contributing.rst
+++ b/docs/04_contributing/04_contributing.rst
@@ -17,11 +17,11 @@ Platform-Specific Configuration
 -------------------------------
 
 **Windows**:
-Since the repository contains symbolic links, make sure to set the following git configuration:
+Since the repository contains symbolic links, make sure this is supported:
 
-  * Enable symlinks for this repository: `git config core.symlinks true`
-  * Enable developer mode to allow symlinks to be created: Search Start Menu for "Developer Settings" and enable "Developer Mode"
-  * Re-checkout the current git state: `git checkout .`
+  * Enable Windows Developer Mode to allow symbolic links to be created: Search Start Menu for "Developer Settings" and enable "Developer Mode"
+  * Enable symbolic links for this repository: ``git config core.symlinks true``
+  * Re-checkout the current git state: ``git checkout .``
 
 
 PEP8 Code Style Check and Formatting

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -981,7 +981,7 @@ class _BuilderMixinDualCriticFactory(_BuilderMixinCriticsFactory):
         return self
 
     def with_critic2_factory_use_actor(self) -> Self:
-        """Makes the first critic reuse the actor's preprocessing network (parameter sharing)."""
+        """Makes the second critic reuse the actor's preprocessing network (parameter sharing)."""
         return self._with_critic_factory_use_actor(1)
 
 

--- a/tianshou/highlevel/experiment.py
+++ b/tianshou/highlevel/experiment.py
@@ -801,6 +801,28 @@ class _BuilderMixinActorFactory_ContinuousDeterministic(_BuilderMixinActorFactor
         return super()._with_actor_factory_default(hidden_sizes, hidden_activation)
 
 
+class _BuilderMixinActorFactory_DiscreteOnly(_BuilderMixinActorFactory):
+    """Specialization of the actor mixin where only environments with discrete action spaces are supported."""
+
+    def __init__(self) -> None:
+        super().__init__(ContinuousActorType.UNSUPPORTED)
+
+    def with_actor_factory_default(
+        self,
+        hidden_sizes: Sequence[int],
+        hidden_activation: ModuleType = torch.nn.ReLU,
+    ) -> Self:
+        """Defines use of the default actor factory, allowing its parameters it to be customized.
+
+        The default actor factory uses an MLP-style architecture.
+
+        :param hidden_sizes: dimensions of hidden layers used by the network
+        :param hidden_activation: the activation function to use for hidden layers
+        :return: the builder
+        """
+        return super()._with_actor_factory_default(hidden_sizes, hidden_activation)
+
+
 class _BuilderMixinCriticsFactory:
     def __init__(self, num_critics: int, actor_future_provider: ActorFutureProviderProtocol):
         self._actor_future_provider = actor_future_provider
@@ -1333,7 +1355,7 @@ class SACExperimentBuilder(
 
 class DiscreteSACExperimentBuilder(
     ExperimentBuilder,
-    _BuilderMixinActorFactory,
+    _BuilderMixinActorFactory_DiscreteOnly,
     _BuilderMixinDualCriticFactory,
 ):
     def __init__(
@@ -1343,7 +1365,7 @@ class DiscreteSACExperimentBuilder(
         sampling_config: SamplingConfig | None = None,
     ):
         super().__init__(env_factory, experiment_config, sampling_config)
-        _BuilderMixinActorFactory.__init__(self, ContinuousActorType.UNSUPPORTED)
+        _BuilderMixinActorFactory_DiscreteOnly.__init__(self)
         _BuilderMixinDualCriticFactory.__init__(self, self)
         self._params: DiscreteSACParams = DiscreteSACParams()
 


### PR DESCRIPTION
- [X] I have added the correct label(s) to this Pull Request or linked the relevant issue(s)
- [X] I have provided a description of the changes in this Pull Request
- [x] I have added documentation for my changes and have listed relevant changes in CHANGELOG.md
- [x] If applicable, I have added tests to cover my changes.
- [x] I have reformatted the code using `poe format` 
- [ ] I have checked style and types with `poe lint` and `poe type-check`
- [ ] (Optional) I ran tests locally with `poe test` 
(or a subset of them with `poe test-reduced`) ,and they pass
- [ ] (Optional) I have tested that documentation builds correctly with `poe doc-build`

Fixes #1248

Additional Changes:
* Add information on Windows-specific developer configuration
* Fix an incorrect docstring 