### PR TITLE
Improve offline algo performance

### DIFF
--- a/tianshou/algorithm/algorithm_base.py
+++ b/tianshou/algorithm/algorithm_base.py
@@ -2,6 +2,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
+from copy import copy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
@@ -943,6 +944,49 @@ class OfflineAlgorithm(
         return super()._update(
             sample_size=sample_size, buffer=buffer, update_with_batch_fn=update_with_batch_fn
         )
+
+
+class OfflineAlgorithmFromOffPolicyAlgorithm(
+    OfflineAlgorithm[TPolicy],
+    Generic[TPolicy],
+    ABC,
+):
+    """Base class for offline algorithms that use the same data preprocessing as an off-policy algorithm.
+
+    Typically used within a diamond inheritance pattern for transforming the respective off-policy algorithm
+    into a derived offline variant. See usages.
+    """
+
+    def __init__(
+        self, *, policy: TPolicy, off_policy_algorithm_class: type[OfflineAlgorithm[TPolicy]]
+    ):
+        self._off_policy_algorithm_class = off_policy_algorithm_class
+        OfflineAlgorithm.__init__(self, policy=policy)
+
+    @override
+    def process_buffer(self, buffer: TBuffer) -> TBuffer:
+        """Use the off-policy algorithm's batch pre-processing for processing the buffer once before training.
+
+        This implementation avoids unnecessary re-computation of preprocessing.
+        """
+        buffer = copy(buffer)
+        batch, indices = buffer.sample(0)
+        processed_batch = self._off_policy_algorithm_class._preprocess_batch(
+            self, batch, buffer, indices  # type: ignore[arg-type]
+        )
+        buffer_batch = copy(buffer._meta)
+        buffer_batch.update(processed_batch)
+        buffer.set_batch(buffer_batch)
+        return buffer
+
+    @override
+    def _preprocess_batch(
+        self,
+        batch: RolloutBatchProtocol,
+        buffer: ReplayBuffer,
+        indices: np.ndarray,
+    ) -> RolloutBatchProtocol | BatchWithReturnsProtocol:
+        return batch
 
 
 class OnPolicyWrapperAlgorithm(

--- a/tianshou/algorithm/algorithm_base.py
+++ b/tianshou/algorithm/algorithm_base.py
@@ -953,15 +953,16 @@ class OfflineAlgorithmFromOffPolicyAlgorithm(
 ):
     """Base class for offline algorithms that use the same data preprocessing as an off-policy algorithm.
 
-    Typically used within a diamond inheritance pattern for transforming the respective off-policy algorithm
-    into a derived offline variant. See usages.
+    Has to be used within a diamond inheritance pattern, as it does not call `super().__init__` in order to not
+    initialize `Algorithm` (and thereby `nn.Module`) twice. The diamond inheritance is used for transforming the respective off-policy algorithm
+    into a derived offline variant, see usages of this class in the codebase.
     """
 
+    # noinspection PyMissingConstructor
     def __init__(
         self, *, policy: TPolicy, off_policy_algorithm_class: type[OfflineAlgorithm[TPolicy]]
     ):
         self._off_policy_algorithm_class = off_policy_algorithm_class
-        OfflineAlgorithm.__init__(self, policy=policy)
 
     @override
     def process_buffer(self, buffer: TBuffer) -> TBuffer:

--- a/tianshou/algorithm/imitation/td3_bc.py
+++ b/tianshou/algorithm/imitation/td3_bc.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 
 from tianshou.algorithm import TD3
-from tianshou.algorithm.algorithm_base import OfflineAlgorithm
+from tianshou.algorithm.algorithm_base import OfflineAlgorithmFromOffPolicyAlgorithm
 from tianshou.algorithm.modelfree.ddpg import ContinuousDeterministicPolicy
 from tianshou.algorithm.modelfree.td3 import TD3TrainingStats
 from tianshou.algorithm.optim import OptimizerFactory
@@ -11,7 +11,7 @@ from tianshou.data.types import RolloutBatchProtocol
 
 
 # NOTE: This uses diamond inheritance to convert from off-policy to offline
-class TD3BC(OfflineAlgorithm[ContinuousDeterministicPolicy], TD3):  # type: ignore
+class TD3BC(OfflineAlgorithmFromOffPolicyAlgorithm[ContinuousDeterministicPolicy], TD3):  # type: ignore
     """Implementation of TD3+BC. arXiv:2106.06860."""
 
     def __init__(
@@ -96,6 +96,9 @@ class TD3BC(OfflineAlgorithm[ContinuousDeterministicPolicy], TD3):  # type: igno
             noise_clip=noise_clip,
             update_actor_freq=update_actor_freq,
             n_step_return_horizon=n_step_return_horizon,
+        )
+        OfflineAlgorithmFromOffPolicyAlgorithm.__init__(
+            self, policy=policy, off_policy_algorithm_class=TD3  # type: ignore[arg-type]
         )
         self.alpha = alpha
 

--- a/tianshou/data/buffer/buffer_base.py
+++ b/tianshou/data/buffer/buffer_base.py
@@ -297,10 +297,8 @@ class ReplayBuffer:
         if not keep_statistics:
             self._ep_return, self._ep_len = 0.0, 0
 
-    # TODO: is this method really necessary? It's kinda dangerous, can accidentally
-    #  remove all references to collected data
     def set_batch(self, batch: RolloutBatchProtocol) -> None:
-        """Manually choose the batch you want the ReplayBuffer to manage."""
+        """Manually choose the batch you want the ReplayBuffer to manage. Use with caution!."""
         assert len(batch) == self.maxsize and set(batch.get_keys()).issubset(
             self._reserved_keys,
         ), "Input batch doesn't meet ReplayBuffer's data form requirement."
@@ -495,12 +493,10 @@ class ReplayBuffer:
     def sample_indices(self, batch_size: int | None) -> np.ndarray:
         """Get a random sample of index with size = batch_size.
 
-        Return all available indices in the buffer if batch_size is 0; return an empty
-        numpy array if batch_size < 0 or no available index can be sampled.
-
-        :param batch_size: the number of indices to be sampled. If None, it will be set
-            to the length of the buffer (i.e. return all available indices in a
-            random order).
+        :param batch_size: the number of indices to be sampled. Three cases are possible:
+            1. positive int - sample random indices of that size
+            2. zero - all indices in current order
+            3. None - all indices but in random order
         """
         if batch_size is None:
             batch_size = len(self)
@@ -533,8 +529,10 @@ class ReplayBuffer:
     def sample(self, batch_size: int | None) -> tuple[RolloutBatchProtocol, np.ndarray]:
         """Get a random sample from buffer with size = batch_size.
 
-        Return all the data in the buffer if batch_size is 0.
-
+        :param batch_size: the number of indices to be sampled. Three cases are possible:
+            1. positive int - sample random indices of that size
+            2. zero - all indices in current order
+            3. None - all indices but in random order
         :return: Sample data and its corresponding index inside the buffer.
         """
         indices = self.sample_indices(batch_size)

--- a/tianshou/data/buffer/buffer_base.py
+++ b/tianshou/data/buffer/buffer_base.py
@@ -299,9 +299,6 @@ class ReplayBuffer:
 
     def set_batch(self, batch: RolloutBatchProtocol) -> None:
         """Manually choose the batch you want the ReplayBuffer to manage. Use with caution!."""
-        assert len(batch) == self.maxsize and set(batch.get_keys()).issubset(
-            self._reserved_keys,
-        ), "Input batch doesn't meet ReplayBuffer's data form requirement."
         self._meta = batch
 
     def unfinished_index(self) -> np.ndarray:


### PR DESCRIPTION
For @arnaujc91 

Background: currently the pre-processing of most offline learning algorithms is done in `_preprocess_batch`, which is highly suboptimal. Instead it should be done in `process_buffer`. 

In this PR, a general class that implements `process_buffer` using `_preprocess_batch` is introduced that allows converting an OffPolicyAlgorithm into an efficient OfflineAlgorithm. 

Current status: when using it to improve performance of `TD3BC`, the algorithm converges and tests pass, but the determinism test fails, meaning something changed in the processing or at least in the random number generation. If it's the latter, the failure is not a problem, but I currently don't see why any rng related things should have changed.

The implementation that changes the buffer's managed batch is rather hacky. I suspect something goes wrong with the indexing but after 20 mins of debugging I haven't yet pinned down what causes the determinism test to fail. Understanding this will require reading through the sample_indices in `ReplayBuffer` and `ReplayBufferManager`. Note that there is inconsistency in how `sample_indices(None)` is handled between the two, but it shouldn't play a role for this PR.

In the course of this PR, determinism snapshots should be created from the dev-v2 branch, then after switching to this branch, the determinism test of td3bc should succeed. See docstring of `AlgorithmDeterminismTest` in `determinism_test.py` for further details.

The PR is finished when all relevant offline algorithms inherit from `OfflineAlgorithmFromOffPolicyAlgorithm` and either the determinism tests pass, or a source of different random number generation caused by the refactoring has been identified.