### PR TITLE
[data collector] Use monotonic clocks for collector timing

### DIFF
--- a/test/base/test_collector.py
+++ b/test/base/test_collector.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import tqdm
 
+import tianshou.data.collector as collector_module
 from test.base.env import MoveToRightEnv, NXEnv
 from tianshou.algorithm.algorithm_base import Policy, episode_mc_return_to_go
 from tianshou.data import (
@@ -1011,3 +1012,31 @@ class TestCollectStatsAndHooks:
         full_return = collected_batch.get(EpisodeRolloutHookMCReturn.FULL_EPISODE_MC_RETURN_KEY)
         assert np.array_equal(return_to_go, episode_mc_return_to_go(collected_batch.rew))
         assert np.array_equal(full_return, np.ones(5) * return_to_go[0])
+
+
+class _ClockWithBackwardWallTime:
+    def __init__(self) -> None:
+        self.wall_times = iter([10.0, 9.0])
+        self.monotonic_times = iter([20.0, 21.5])
+
+    def time(self) -> float:
+        return next(self.wall_times)
+
+    def monotonic(self) -> float:
+        return next(self.monotonic_times)
+
+    @staticmethod
+    def sleep(seconds: float) -> None:
+        pass
+
+
+def test_collector_uses_monotonic_time_for_collect_duration(
+    collector_with_single_env: Collector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(collector_module, "time", _ClockWithBackwardWallTime())
+
+    collect_stats = collector_with_single_env.collect(n_step=3)
+
+    assert collect_stats.collect_time == 1.5
+    assert collect_stats.collect_speed == 2.0

--- a/tianshou/data/collector.py
+++ b/tianshou/data/collector.py
@@ -498,7 +498,8 @@ class BaseCollector(Generic[TCollectStats], ABC):
         if reset_before_collect:
             self.reset(reset_buffer=False, gym_reset_kwargs=gym_reset_kwargs)
 
-        pre_collect_time = time.time()
+        # Use a monotonic clock so elapsed-time measurement is immune to wall-clock adjustments.
+        pre_collect_time = time.monotonic()
         with torch_train_mode(self.policy, enabled=False):
             collect_stats = self._collect(
                 n_step=n_step,
@@ -507,7 +508,7 @@ class BaseCollector(Generic[TCollectStats], ABC):
                 render=render,
                 gym_reset_kwargs=gym_reset_kwargs,
             )
-        collect_time = time.time() - pre_collect_time
+        collect_time = time.monotonic() - pre_collect_time
         collect_stats.set_collect_time(collect_time, update_collect_speed=True)
         collect_stats.refresh_all_sequence_stats()
 
@@ -1207,7 +1208,7 @@ class AsyncCollector(Collector[CollectStats]):
         render: float | None = None,
         gym_reset_kwargs: dict[str, Any] | None = None,
     ) -> CollectStats:
-        start_time = time.time()
+        start_time = time.monotonic()
 
         step_count = 0
         num_collected_episodes = 0
@@ -1382,7 +1383,7 @@ class AsyncCollector(Collector[CollectStats]):
         # generate statistics
         self.collect_step += step_count
         self.collect_episode += num_collected_episodes
-        collect_time = max(time.time() - start_time, 1e-9)
+        collect_time = max(time.monotonic() - start_time, 1e-9)
         self.collect_time += collect_time
 
         # persist for future collect iterations


### PR DESCRIPTION
## Summary
- Problem: `Collector.collect()` measures elapsed time with `time.time()`, so a wall-clock rollback can produce negative `collect_time` and raise `ValueError` in `CollectStats.set_collect_time`.
- Scope: switch collector elapsed-time measurements to `time.monotonic()` and add a regression test that simulates wall-clock rollback.
- Outcome: collector stats stay valid across system clock adjustments, and the issue report is covered by a dedicated test.

Fixes #1291.

## Technical Details
- Approach: use a monotonic clock for both the synchronous `BaseCollector.collect` wrapper and `AsyncCollector._collect` internal timing so elapsed durations are independent of wall-clock/NTP adjustments.
- Code pointers:
  - `tianshou/data/collector.py`: switch elapsed-time sources to `time.monotonic()`.
  - `test/base/test_collector.py`: add a fake clock regression test where `time.time()` goes backward while `time.monotonic()` increases.
- Notes: no API change; this only affects internal duration measurement and derived collect speed.

## Test Plan
### Automated
- `pytest test/base/test_collector.py -k 'monotonic_time or test_collector_with_vector_env or test_async_collector_with_vector_env' -q`: passed
- `pytest test/base/test_collector.py -q`: passed, 17 passed
- `ruff check tianshou/data/collector.py test/base/test_collector.py`: passed
- `ruff format --check tianshou/data/collector.py test/base/test_collector.py`: passed
### Suggested Manual
- `collector.collect(...)` under a host clock adjustment: verify training no longer crashes with a negative `collect_time`.
